### PR TITLE
Add global error overlay and base UI

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -16,8 +16,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 
 ---
 
-1. **Globale Fehlerbehandlung** – Füge ein zentrales Fehler-Overlay hinzu, das Fehler (JavaScript-Exceptions oder nicht geladene Daten) abfängt und benutzerfreundlich darstellt.  
-   Status: ⬜
+1. **Globale Fehlerbehandlung** – Füge ein zentrales Fehler-Overlay hinzu, das Fehler (JavaScript-Exceptions oder nicht geladene Daten) abfängt und benutzerfreundlich darstellt.
+   Status: ✅ erledigt – 2025-11-04
 
 2. **CI/CD-Workflow für GitHub Pages** – Lege eine GitHub Actions Workflow-Datei an (`.github/workflows/deploy.yml`), die das Projekt bei jedem Push auf den `main`-Branch automatisch auf GitHub Pages deployt.  
    Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,202 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.6;
+  background-color: #f4f6fb;
+  color: #1f2933;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background: linear-gradient(135deg, #1f3c88, #2f74c0);
+  color: #fff;
+  padding: 2rem clamp(1.5rem, 4vw, 4rem);
+  text-align: center;
+  box-shadow: 0 2px 12px rgba(31, 60, 136, 0.4);
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 5vw, 2.8rem);
+}
+
+.app-subtitle {
+  margin: 0;
+  font-size: clamp(1rem, 2.5vw, 1.2rem);
+  letter-spacing: 0.02em;
+  opacity: 0.85;
+}
+
+.app-main {
+  flex: 1;
+  display: grid;
+  place-items: center;
+  padding: clamp(1.5rem, 5vw, 4rem);
+}
+
+.app-card {
+  width: min(650px, 100%);
+  background: #fff;
+  border-radius: 16px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(31, 60, 136, 0.08);
+}
+
+.app-card h2 {
+  margin-top: 0;
+  font-size: clamp(1.5rem, 3vw, 1.9rem);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  padding: 0.75rem 1.4rem;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.2s;
+}
+
+.btn:focus-visible {
+  outline: 3px solid rgba(47, 116, 192, 0.4);
+  outline-offset: 2px;
+}
+
+.btn-primary {
+  background: #2f74c0;
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(47, 116, 192, 0.35);
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(47, 116, 192, 0.38);
+}
+
+.btn-secondary {
+  background: #fff;
+  color: #1f2933;
+  border-color: rgba(47, 116, 192, 0.35);
+}
+
+.btn-secondary:hover {
+  background: rgba(47, 116, 192, 0.08);
+}
+
+.error-overlay[hidden] {
+  display: none;
+}
+
+.error-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.65);
+  display: grid;
+  place-items: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  z-index: 999;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.error-overlay__content {
+  width: min(520px, 100%);
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+}
+
+.error-overlay__header {
+  background: #2f74c0;
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+}
+
+.error-overlay__close {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.75rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 0.25rem;
+}
+
+.error-overlay__message {
+  padding: 1.25rem;
+  font-size: 1.05rem;
+  color: #1f2933;
+  background: linear-gradient(180deg, rgba(47, 116, 192, 0.06), transparent);
+}
+
+.error-overlay__details {
+  margin: 0;
+  padding: 0 1.25rem 1.25rem;
+}
+
+.error-overlay__details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: #2f74c0;
+  margin-bottom: 0.75rem;
+}
+
+.error-overlay__details pre {
+  margin: 0;
+  padding: 1rem;
+  background: #0f172a;
+  color: #f9fafb;
+  border-radius: 12px;
+  max-height: 180px;
+  overflow: auto;
+  font-size: 0.85rem;
+}
+
+.error-overlay__footer {
+  margin-top: auto;
+  padding: 1rem 1.25rem 1.25rem;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 600px) {
+  .app-card {
+    padding: 1.25rem;
+  }
+
+  .error-overlay__footer {
+    justify-content: stretch;
+  }
+
+  .error-overlay__footer .btn {
+    flex: 1 1 auto;
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,154 @@
+class GlobalErrorOverlay {
+  constructor(root) {
+    this.root = root;
+    this.messageEl = root.querySelector('#error-overlay-message');
+    this.detailsEl = root.querySelector('#error-overlay-details');
+    this.dismissButtons = root.querySelectorAll('[data-error-action="dismiss"]');
+    this.reloadButton = root.querySelector('[data-error-action="reload"]');
+    this.isVisible = false;
+
+    this.dismissButtons.forEach((btn) =>
+      btn.addEventListener('click', () => this.hide())
+    );
+
+    if (this.reloadButton) {
+      this.reloadButton.addEventListener('click', () => {
+        window.location.reload();
+      });
+    }
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && this.isVisible) {
+        this.hide();
+      }
+    });
+  }
+
+  show({ title, message, details }) {
+    if (title) {
+      const titleEl = this.root.querySelector('#error-overlay-title');
+      if (titleEl) {
+        titleEl.textContent = title;
+      }
+    }
+
+    this.messageEl.textContent = message ?? 'Ein unbekannter Fehler ist aufgetreten.';
+
+    if (details) {
+      this.detailsEl.textContent = details;
+      this.detailsEl.parentElement.removeAttribute('hidden');
+    } else {
+      this.detailsEl.textContent = '';
+      this.detailsEl.parentElement.setAttribute('hidden', '');
+    }
+
+    this.root.removeAttribute('hidden');
+    this.root.setAttribute('aria-hidden', 'false');
+    this.isVisible = true;
+    this.root.querySelector('.error-overlay__content')?.focus?.();
+  }
+
+  hide() {
+    this.root.setAttribute('hidden', '');
+    this.root.setAttribute('aria-hidden', 'true');
+    this.isVisible = false;
+  }
+}
+
+function formatErrorDetails(error) {
+  if (!error) return '';
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return [error.message, error.stack].filter(Boolean).join('\n');
+  }
+
+  try {
+    return JSON.stringify(error, null, 2);
+  } catch (jsonError) {
+    return String(error);
+  }
+}
+
+function initGlobalErrorHandling() {
+  const overlayRoot = document.getElementById('global-error-overlay');
+  if (!overlayRoot) {
+    console.warn('Global error overlay root element not found.');
+    return;
+  }
+
+  const overlay = new GlobalErrorOverlay(overlayRoot);
+
+  const showFromEvent = (event) => {
+    const { error, reason, message, filename, lineno, colno } = event;
+    const detailSource = error ?? reason;
+    const formattedDetails = formatErrorDetails(detailSource);
+
+    const overlayTitle = 'Ein unerwarteter Fehler ist aufgetreten';
+    const overlayMessage =
+      (message && typeof message === 'string')
+        ? message
+        : 'Bitte entschuldigen Sie die Umstände. Wir kümmern uns sofort darum.';
+
+    const meta = [];
+    if (filename) {
+      meta.push(`Datei: ${filename}`);
+    }
+    if (typeof lineno === 'number') {
+      meta.push(`Zeile: ${lineno}`);
+    }
+    if (typeof colno === 'number') {
+      meta.push(`Spalte: ${colno}`);
+    }
+
+    const details = [formattedDetails, meta.join(' | ')].filter(Boolean).join('\n\n');
+
+    overlay.show({ title: overlayTitle, message: overlayMessage, details });
+  };
+
+  window.addEventListener('error', (event) => {
+    event.preventDefault();
+    showFromEvent(event);
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    event.preventDefault();
+    showFromEvent(event);
+  });
+
+  window.addEventListener('verilex:error', (event) => {
+    const detail = event.detail ?? {};
+    overlay.show({
+      title: detail.title ?? 'Fehler',
+      message:
+        detail.message ??
+        'Es ist ein Problem aufgetreten. Bitte versuchen Sie es erneut.',
+      details: formatErrorDetails(detail.details),
+    });
+  });
+
+  return overlay;
+}
+
+const overlayInstance = initGlobalErrorHandling();
+
+const demoButton = document.getElementById('trigger-demo-error');
+if (demoButton) {
+  demoButton.addEventListener('click', () => {
+    const demoError = new Error('Dies ist ein simuliertes Fehlerbeispiel für das Overlay.');
+    window.dispatchEvent(
+      new CustomEvent('verilex:error', {
+        detail: {
+          title: 'Demo-Fehler',
+          message: 'So sieht das Fehler-Overlay bei einer Ausnahme aus.',
+          details: demoError,
+        },
+      })
+    );
+  });
+}
+
+export { GlobalErrorOverlay, overlayInstance };

--- a/index.html
+++ b/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Kanzlei-Demo</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>VeriLex Demo</h1>
+      <p class="app-subtitle">Digitale Workflows für Kanzleien</p>
+    </header>
+
+    <main class="app-main" aria-live="polite">
+      <section class="app-card">
+        <h2>Willkommen</h2>
+        <p>
+          Diese Oberfläche wird Schritt für Schritt gemäß der Aufgabenliste in
+          <code>ToDo.md</code> erweitert. Aktuell ist ein globales Fehler-Overlay
+          aktiv, das Ausnahmesituationen für Nutzer:innen sichtbar macht.
+        </p>
+        <button type="button" id="trigger-demo-error" class="btn btn-primary">
+          Demo-Fehler auslösen
+        </button>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details">
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">
+            Seite neu laden
+          </button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">
+            Schließen
+          </button>
+        </footer>
+      </div>
+    </div>
+
+    <script src="assets/js/app.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a static HTML entry point with a welcome card and demo trigger
- implement global error overlay markup, styles, and behavior to capture runtime issues
- update the project checklist to record completion of the global error handling task

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690a036d10e883209e5e07c6752d4c4c