### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/ToDo.md
+++ b/ToDo.md
@@ -19,8 +19,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 1. **Globale Fehlerbehandlung** – Füge ein zentrales Fehler-Overlay hinzu, das Fehler (JavaScript-Exceptions oder nicht geladene Daten) abfängt und benutzerfreundlich darstellt.
    Status: ✅ erledigt – 2025-11-04
 
-2. **CI/CD-Workflow für GitHub Pages** – Lege eine GitHub Actions Workflow-Datei an (`.github/workflows/deploy.yml`), die das Projekt bei jedem Push auf den `main`-Branch automatisch auf GitHub Pages deployt.  
-   Status: ⬜
+2. **CI/CD-Workflow für GitHub Pages** – Lege eine GitHub Actions Workflow-Datei an (`.github/workflows/deploy.yml`), die das Projekt bei jedem Push auf den `main`-Branch automatisch auf GitHub Pages deployt.
+   Status: ✅ erledigt – 2025-11-04
 
 3. **Aktenliste mit Suche** – Erstelle eine übersichtliche Liste aller Demo-Akten. Die Liste soll responsiv im Grid angezeigt werden und eine Suchleiste enthalten, die nach Titel oder Aktennummer filtert. Verwende Platzhalterdaten im JSON-Format. Achte auf klare Darstellung (Titel, Mandant, Friststatus) und Keyboard-Navigation.  
    Status: ⬜


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys the static site to GitHub Pages on pushes to main
- mark the CI/CD workflow task as complete in the project ToDo list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a05f20da08320aed54d9429da229f