### PR TITLE
Add case detail page with timeline view

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -25,8 +25,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 3. **Aktenliste mit Suche** – Erstelle eine übersichtliche Liste aller Demo-Akten. Die Liste soll responsiv im Grid angezeigt werden und eine Suchleiste enthalten, die nach Titel oder Aktennummer filtert. Verwende Platzhalterdaten im JSON-Format. Achte auf klare Darstellung (Titel, Mandant, Friststatus) und Keyboard-Navigation.
    Status: ✅ erledigt – 2025-11-04
 
-4. **Akten-Detailseite & Timeline** – Baue eine Detailseite, die die Historie eines Akts als chronologische Timeline darstellt (Dokumente, Notizen, Fristen, Aktivitäten). Nutze ein responsives Layout mit Seitenleiste für Akteninfos.  
-   Status: ⬜
+4. **Akten-Detailseite & Timeline** – Baue eine Detailseite, die die Historie eines Akts als chronologische Timeline darstellt (Dokumente, Notizen, Fristen, Aktivitäten). Nutze ein responsives Layout mit Seitenleiste für Akteninfos.
+   Status: ✅ erledigt – 2025-11-04
 
 5. **Mandats-Wizard (mehrstufig)** – Erstelle einen Wizard mit mehreren Schritten zur Mandatsanlage (Klientendaten → Gegner → Akteninhalt → Abschluss). Jeder Schritt soll eigene Validierung und Fortschrittsanzeige besitzen.  
    Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -407,3 +407,356 @@ body {
     width: 100%;
   }
 }
+
+.case-detail-main {
+  align-items: stretch;
+}
+
+.case-breadcrumb {
+  width: min(1100px, 100%);
+  margin: 0 auto clamp(0.5rem, 2vw, 1rem);
+}
+
+.case-breadcrumb__link {
+  color: #1f3c88;
+  font-weight: 600;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.case-breadcrumb__link:hover,
+.case-breadcrumb__link:focus {
+  text-decoration: underline;
+}
+
+.case-detail-card {
+  width: min(1100px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.case-detail-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-end;
+  border-bottom: 1px solid rgba(31, 60, 136, 0.12);
+  padding-bottom: 1rem;
+}
+
+.case-detail__number {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: #2f74c0;
+  text-transform: uppercase;
+}
+
+.case-detail__title {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+}
+
+.case-detail__status-group {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.case-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(47, 116, 192, 0.12);
+  color: #1f3c88;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-weight: 600;
+}
+
+.case-status-pill--muted {
+  background: rgba(15, 23, 42, 0.08);
+  color: #1f2933;
+}
+
+.case-detail-layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.case-sidebar {
+  background: rgba(47, 116, 192, 0.04);
+  border: 1px solid rgba(47, 116, 192, 0.12);
+  border-radius: 16px;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.case-sidebar__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.case-sidebar__heading {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #1f3c88;
+}
+
+.case-sidebar__meta {
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.case-sidebar__meta div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.case-sidebar__meta dt {
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.case-sidebar__meta dd {
+  margin: 0;
+  color: #1f2933;
+}
+
+.case-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.case-tag {
+  background: rgba(47, 116, 192, 0.18);
+  color: #1d4ed8;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.case-tags__empty {
+  color: #64748b;
+}
+
+.case-next-steps {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.case-next-steps li {
+  color: #1f2933;
+}
+
+.case-next-steps__empty {
+  list-style: none;
+  padding-left: 0;
+  color: #64748b;
+}
+
+.case-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.case-timeline__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.case-timeline__summary {
+  margin: 0.35rem 0 0;
+  color: #4b5563;
+}
+
+.case-timeline__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.timeline-filter {
+  border: 1px solid rgba(47, 116, 192, 0.3);
+  background: #fff;
+  color: #1f3c88;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.timeline-filter:hover,
+.timeline-filter:focus-visible {
+  background: rgba(47, 116, 192, 0.08);
+  outline: none;
+}
+
+.timeline-filter--active {
+  background: #2f74c0;
+  color: #fff;
+  border-color: #2f74c0;
+}
+
+.timeline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.2rem;
+  position: relative;
+}
+
+.timeline-list::before {
+  content: '';
+  position: absolute;
+  left: 22px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(47, 116, 192, 0.3), rgba(47, 116, 192, 0));
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  gap: 1rem;
+  position: relative;
+  padding-left: 10px;
+}
+
+.timeline-item__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: #fff;
+  border: 2px solid rgba(47, 116, 192, 0.35);
+  font-size: 1.35rem;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+}
+
+.timeline-item__content {
+  background: #fff;
+  border: 1px solid rgba(31, 60, 136, 0.12);
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 16px 35px rgba(15, 23, 42, 0.08);
+}
+
+.timeline-item__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.timeline-item__title {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #1f2933;
+}
+
+.timeline-item__time {
+  color: #475569;
+  font-weight: 600;
+}
+
+.timeline-item__description {
+  margin: 0 0 0.75rem;
+  color: #334155;
+}
+
+.timeline-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.timeline-meta__item {
+  background: rgba(15, 23, 42, 0.05);
+  border-radius: 999px;
+  padding: 0.2rem 0.75rem;
+}
+
+.timeline-item--deadline .timeline-item__icon {
+  border-color: rgba(248, 113, 113, 0.55);
+}
+
+.timeline-item--document .timeline-item__icon {
+  border-color: rgba(59, 130, 246, 0.55);
+}
+
+.timeline-item--note .timeline-item__icon {
+  border-color: rgba(251, 191, 36, 0.55);
+}
+
+.timeline-item--activity .timeline-item__icon {
+  border-color: rgba(16, 185, 129, 0.55);
+}
+
+.timeline-empty {
+  margin: 0;
+  padding: 1rem;
+  text-align: center;
+  background: rgba(15, 23, 42, 0.05);
+  border-radius: 12px;
+  color: #475569;
+}
+
+@media (max-width: 960px) {
+  .case-detail-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .case-sidebar {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .case-sidebar__section {
+    flex: 1 1 240px;
+  }
+}
+
+@media (max-width: 720px) {
+  .case-sidebar {
+    flex-direction: column;
+  }
+
+  .timeline-item {
+    grid-template-columns: 1fr;
+    padding-left: 0;
+  }
+
+  .timeline-list::before {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .timeline-item__icon {
+    margin: 0 auto;
+  }
+}
+

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -208,6 +208,22 @@ function initCaseDirectory() {
     summary.textContent = selectionMessage ? `${baseMessage} — ${selectionMessage}` : baseMessage;
   };
 
+  const buildCaseDetailUrl = (caseEntry) => {
+    const caseNumber = caseEntry.caseNumber?.trim();
+    if (!caseNumber) {
+      return 'case-detail.html';
+    }
+
+    const params = new URLSearchParams();
+    params.set('case', caseNumber);
+    return `case-detail.html?${params.toString()}`;
+  };
+
+  const navigateToDetail = (caseEntry) => {
+    const url = buildCaseDetailUrl(caseEntry);
+    window.location.href = url;
+  };
+
   const renderList = (list) => {
     grid.innerHTML = '';
     const fragment = document.createDocumentFragment();
@@ -237,10 +253,12 @@ function initCaseDirectory() {
           <span>${caseEntry.client || 'unbekannt'}</span>
         </p>
         <div class="case-card__footer">
-          <span class="case-card__action-hint">Enter oder Leertaste markiert die Akte</span>
+          <span class="case-card__action-hint">Enter öffnet die Detailseite, Leertaste markiert</span>
           <span class="case-card__icon" aria-hidden="true">⟶</span>
         </div>
       `;
+
+      card.addEventListener('click', () => navigateToDetail(caseEntry));
 
       fragment.appendChild(card);
     });
@@ -280,7 +298,7 @@ function initCaseDirectory() {
       return;
     }
 
-    selectionMessage = `Akte „${caseEntry.title || caseEntry.caseNumber}“ markiert`;
+    selectionMessage = `Akte „${caseEntry.title || caseEntry.caseNumber}“ markiert. Enter öffnet die Detailseite.`;
     updateSummary(currentList.length);
   };
 
@@ -325,7 +343,13 @@ function initCaseDirectory() {
       return;
     }
 
-    if (event.key === ' ' || event.key === 'Enter') {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      navigateToDetail(currentList[index]);
+      return;
+    }
+
+    if (event.key === ' ') {
       event.preventDefault();
       announceSelection(currentList[index]);
     }

--- a/assets/js/case-detail.js
+++ b/assets/js/case-detail.js
@@ -1,0 +1,297 @@
+import { overlayInstance } from './app.js';
+
+function parseCaseData() {
+  const dataElement = document.getElementById('case-detail-data');
+  if (!dataElement) {
+    return { cases: [] };
+  }
+
+  try {
+    const raw = dataElement.textContent ?? '{}';
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch (error) {
+    console.error('Die Falldaten konnten nicht geladen werden.', error);
+    overlayInstance?.show?.({
+      title: 'Daten konnten nicht geladen werden',
+      message: 'Die Detailinformationen zur Akte stehen derzeit nicht zur Verfügung.',
+      details: error,
+    });
+  }
+
+  return { cases: [] };
+}
+
+function getCurrentCase(allCases) {
+  const params = new URLSearchParams(window.location.search);
+  const caseNumber = params.get('case');
+
+  if (caseNumber) {
+    const match = allCases.find(
+      (entry) => entry.caseNumber?.toString().toLowerCase() === caseNumber.toString().toLowerCase()
+    );
+    if (match) {
+      return match;
+    }
+  }
+
+  return allCases[0];
+}
+
+function formatDateTime(value) {
+  if (!value) {
+    return '—';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('de-DE', {
+    dateStyle: 'long',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+function createTagElement(label) {
+  const span = document.createElement('span');
+  span.className = 'case-tag';
+  span.textContent = label;
+  span.setAttribute('role', 'listitem');
+  return span;
+}
+
+function renderSidebar(caseData) {
+  const numberEl = document.getElementById('case-number');
+  const titleEl = document.getElementById('case-detail-title');
+  const clientEl = document.getElementById('case-client');
+  const responsibleEl = document.getElementById('case-responsible');
+  const practiceEl = document.getElementById('case-practice');
+  const updatedEl = document.getElementById('case-updated');
+  const statusEl = document.getElementById('case-status');
+  const priorityEl = document.getElementById('case-priority');
+  const tagsContainer = document.getElementById('case-tags');
+  const stepsContainer = document.getElementById('case-next-steps');
+
+  if (!numberEl || !titleEl) {
+    return;
+  }
+
+  document.title = `VeriLex – ${caseData.title ?? 'Akten-Detail'}`;
+
+  numberEl.textContent = caseData.caseNumber ?? 'Ohne Aktenzeichen';
+  titleEl.textContent = caseData.title ?? 'Unbenannte Akte';
+  clientEl.textContent = caseData.client ?? 'Nicht hinterlegt';
+  responsibleEl.textContent = caseData.responsible ?? 'Noch nicht zugewiesen';
+  practiceEl.textContent = caseData.practiceArea ?? '—';
+  updatedEl.textContent = formatDateTime(caseData.lastUpdated);
+  statusEl.textContent = caseData.status ?? 'Status unbekannt';
+  priorityEl.textContent = caseData.priority ?? '';
+
+  tagsContainer.innerHTML = '';
+  const tags = Array.isArray(caseData.tags) ? caseData.tags : [];
+  if (tags.length === 0) {
+    const emptyTag = document.createElement('span');
+    emptyTag.className = 'case-tags__empty';
+    emptyTag.textContent = 'Keine Tags hinterlegt';
+    tagsContainer.appendChild(emptyTag);
+  } else {
+    const fragment = document.createDocumentFragment();
+    tags.forEach((tag) => fragment.appendChild(createTagElement(tag)));
+    tagsContainer.appendChild(fragment);
+  }
+
+  stepsContainer.innerHTML = '';
+  const steps = Array.isArray(caseData.nextSteps) ? caseData.nextSteps : [];
+  if (steps.length === 0) {
+    const emptyStep = document.createElement('li');
+    emptyStep.className = 'case-next-steps__empty';
+    emptyStep.textContent = 'Keine nächsten Schritte definiert.';
+    stepsContainer.appendChild(emptyStep);
+  } else {
+    const fragment = document.createDocumentFragment();
+    steps.forEach((step) => {
+      const li = document.createElement('li');
+      li.textContent = step;
+      fragment.appendChild(li);
+    });
+    stepsContainer.appendChild(fragment);
+  }
+}
+
+const ICON_MAP = {
+  document: '📄',
+  deadline: '⏰',
+  note: '📝',
+  activity: '✅',
+};
+
+const FILTER_LABELS = {
+  all: 'Alle Ereignisse',
+  document: 'Dokumente',
+  deadline: 'Fristen',
+  note: 'Notizen',
+  activity: 'Aktivitäten',
+};
+
+function createTimelineItem(event) {
+  const li = document.createElement('li');
+  li.className = `timeline-item timeline-item--${event.type ?? 'note'}`;
+  li.dataset.type = event.type ?? 'note';
+
+  const icon = ICON_MAP[event.type] ?? '🗂️';
+  const title = event.title ?? 'Unbenanntes Ereignis';
+  const description = event.description ?? '';
+  const timestamp = formatDateTime(event.timestamp);
+
+  li.innerHTML = `
+    <div class="timeline-item__icon" aria-hidden="true">${icon}</div>
+    <div class="timeline-item__content">
+      <header class="timeline-item__header">
+        <h4 class="timeline-item__title">${title}</h4>
+        <time class="timeline-item__time" datetime="${event.timestamp ?? ''}">${timestamp}</time>
+      </header>
+      <p class="timeline-item__description">${description}</p>
+      ${renderTimelineMeta(event)}
+    </div>
+  `;
+
+  return li;
+}
+
+function renderTimelineMeta(event) {
+  const metaEntries = [];
+  if (event.author) {
+    metaEntries.push(`<span class="timeline-meta__item">Autor: ${event.author}</span>`);
+  }
+  if (event.attachment) {
+    metaEntries.push(`<span class="timeline-meta__item">Anhang: ${event.attachment}</span>`);
+  }
+  if (event.status) {
+    metaEntries.push(`<span class="timeline-meta__item">Status: ${event.status}</span>`);
+  }
+  if (event.duration) {
+    metaEntries.push(`<span class="timeline-meta__item">Dauer: ${event.duration}</span>`);
+  }
+
+  if (metaEntries.length === 0) {
+    return '';
+  }
+
+  return `<div class="timeline-meta">${metaEntries.join('')}</div>`;
+}
+
+function sortTimeline(events) {
+  return events
+    .slice()
+    .sort((a, b) => {
+      const dateA = new Date(a.timestamp ?? 0).getTime();
+      const dateB = new Date(b.timestamp ?? 0).getTime();
+      return dateB - dateA;
+    });
+}
+
+function renderTimeline(events) {
+  const listEl = document.getElementById('case-timeline-list');
+  const summaryEl = document.getElementById('case-timeline-summary');
+  const emptyEl = document.getElementById('case-timeline-empty');
+
+  if (!listEl || !summaryEl || !emptyEl) {
+    return [];
+  }
+
+  listEl.innerHTML = '';
+
+  const sorted = sortTimeline(events);
+  const fragment = document.createDocumentFragment();
+  sorted.forEach((event) => fragment.appendChild(createTimelineItem(event)));
+  listEl.appendChild(fragment);
+
+  const count = sorted.length;
+  summaryEl.textContent =
+    count === 1 ? '1 Ereignis in der Historie' : `${count} Ereignisse in der Historie`;
+
+  emptyEl.hidden = count !== 0;
+
+  return Array.from(listEl.querySelectorAll('.timeline-item'));
+}
+
+function applyTimelineFilter(items, filter) {
+  let visibleCount = 0;
+  items.forEach((item) => {
+    const matches = filter === 'all' || item.dataset.type === filter;
+    item.hidden = !matches;
+    if (matches) {
+      visibleCount += 1;
+    }
+  });
+
+  const emptyEl = document.getElementById('case-timeline-empty');
+  if (emptyEl) {
+    emptyEl.hidden = visibleCount !== 0;
+  }
+
+  const summaryEl = document.getElementById('case-timeline-summary');
+  if (summaryEl) {
+    const filterLabel = FILTER_LABELS[filter] ?? filter;
+    const suffix = filter === 'all' ? '' : ` (Filter: ${filterLabel})`;
+    summaryEl.textContent =
+      visibleCount === 1
+        ? `1 Ereignis in der Historie${suffix}`
+        : `${visibleCount} Ereignisse in der Historie${suffix}`;
+  }
+}
+
+function initTimelineFilters(items) {
+  const buttons = Array.from(document.querySelectorAll('.timeline-filter'));
+  if (buttons.length === 0) {
+    return;
+  }
+
+  const setActive = (activeButton) => {
+    buttons.forEach((btn) => {
+      if (btn === activeButton) {
+        btn.classList.add('timeline-filter--active');
+      } else {
+        btn.classList.remove('timeline-filter--active');
+      }
+    });
+  };
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const filter = button.dataset.filter ?? 'all';
+      setActive(button);
+      applyTimelineFilter(items, filter);
+    });
+  });
+}
+
+function initCaseDetail() {
+  const { cases } = parseCaseData();
+  if (!Array.isArray(cases) || cases.length === 0) {
+    overlayInstance?.show?.({
+      title: 'Keine Akteninformationen',
+      message: 'Für die Detailansicht konnten keine Akten geladen werden.',
+    });
+    return;
+  }
+
+  const currentCase = getCurrentCase(cases);
+  if (!currentCase) {
+    overlayInstance?.show?.({
+      title: 'Akte nicht gefunden',
+      message: 'Die angeforderte Akte konnte nicht ermittelt werden.',
+    });
+    return;
+  }
+
+  renderSidebar(currentCase);
+  const timelineItems = renderTimeline(Array.isArray(currentCase.timeline) ? currentCase.timeline : []);
+  initTimelineFilters(timelineItems);
+}
+
+initCaseDetail();

--- a/case-detail.html
+++ b/case-detail.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Akten-Detail</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>VeriLex Demo</h1>
+      <p class="app-subtitle">Aktenhistorie &amp; Timeline</p>
+    </header>
+
+    <main class="app-main case-detail-main" aria-live="polite">
+      <nav class="case-breadcrumb" aria-label="Brotkrumen">
+        <a class="case-breadcrumb__link" href="index.html">&larr; Zur Aktenübersicht</a>
+      </nav>
+
+      <section class="case-card case-detail-card" aria-labelledby="case-detail-title">
+        <header class="case-detail-card__header">
+          <div>
+            <p id="case-number" class="case-detail__number" aria-live="polite"></p>
+            <h2 id="case-detail-title" class="case-detail__title"></h2>
+          </div>
+          <div class="case-detail__status-group">
+            <span id="case-status" class="case-status-pill" role="status"></span>
+            <span id="case-priority" class="case-status-pill case-status-pill--muted"></span>
+          </div>
+        </header>
+
+        <div class="case-detail-layout">
+          <aside class="case-sidebar" aria-label="Akteninformationen">
+            <section class="case-sidebar__section">
+              <h3 class="case-sidebar__heading">Mandant &amp; Team</h3>
+              <dl class="case-sidebar__meta">
+                <div>
+                  <dt>Mandant</dt>
+                  <dd id="case-client"></dd>
+                </div>
+                <div>
+                  <dt>Verantwortliche Person</dt>
+                  <dd id="case-responsible"></dd>
+                </div>
+                <div>
+                  <dt>Rechtsgebiet</dt>
+                  <dd id="case-practice"></dd>
+                </div>
+                <div>
+                  <dt>Letzte Aktualisierung</dt>
+                  <dd id="case-updated"></dd>
+                </div>
+              </dl>
+            </section>
+
+            <section class="case-sidebar__section">
+              <h3 class="case-sidebar__heading">Tags</h3>
+              <div id="case-tags" class="case-tags" role="list"></div>
+            </section>
+
+            <section class="case-sidebar__section">
+              <h3 class="case-sidebar__heading">Nächste Schritte</h3>
+              <ul id="case-next-steps" class="case-next-steps"></ul>
+            </section>
+          </aside>
+
+          <section class="case-timeline" aria-labelledby="case-timeline-title">
+            <header class="case-timeline__header">
+              <div>
+                <h3 id="case-timeline-title">Timeline</h3>
+                <p id="case-timeline-summary" class="case-timeline__summary"></p>
+              </div>
+              <div class="case-timeline__filters" role="group" aria-label="Timeline filtern">
+                <button type="button" class="timeline-filter timeline-filter--active" data-filter="all">
+                  Alle Ereignisse
+                </button>
+                <button type="button" class="timeline-filter" data-filter="document">Dokumente</button>
+                <button type="button" class="timeline-filter" data-filter="deadline">Fristen</button>
+                <button type="button" class="timeline-filter" data-filter="note">Notizen</button>
+                <button type="button" class="timeline-filter" data-filter="activity">Aktivitäten</button>
+              </div>
+            </header>
+
+            <ol id="case-timeline-list" class="timeline-list"></ol>
+            <p id="case-timeline-empty" class="timeline-empty" hidden>
+              Für den ausgewählten Filter sind keine Timeline-Einträge vorhanden.
+            </p>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details" hidden>
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">
+            Seite neu laden
+          </button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">
+            Schließen
+          </button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="application/json" id="case-detail-data">
+      {
+        "cases": [
+          {
+            "caseNumber": "V-2024-001",
+            "title": "Vertragsprüfung Müller GmbH",
+            "client": "Müller GmbH",
+            "status": "In Bearbeitung",
+            "priority": "Hoch",
+            "practiceArea": "Gesellschaftsrecht",
+            "responsible": "RAin Dr. Hannah Keller",
+            "lastUpdated": "2025-11-03T14:30:00+01:00",
+            "tags": ["Due Diligence", "Komplex"],
+            "nextSteps": [
+              "Feedback der Mandantin im Jour fixe dokumentieren",
+              "Finalen Vertragsentwurf bis 08.11. versenden"
+            ],
+            "timeline": [
+              {
+                "id": "evt-01",
+                "type": "document",
+                "title": "Vertragsentwurf – Fassung 3",
+                "description": "Aktualisierter Vertragsentwurf mit eingearbeiteten Klauseln zur Haftungsbegrenzung hochgeladen.",
+                "timestamp": "2025-11-03T09:45:00+01:00",
+                "author": "RAin Dr. Hannah Keller",
+                "attachment": "Vertrag_V3.pdf"
+              },
+              {
+                "id": "evt-02",
+                "type": "note",
+                "title": "Mandantennotiz",
+                "description": "Telefonnotiz: Frau Müller bittet um Klarstellung der Wettbewerbsverbotsklausel.",
+                "timestamp": "2025-11-02T16:10:00+01:00",
+                "author": "RA Felix Sommer"
+              },
+              {
+                "id": "evt-03",
+                "type": "deadline",
+                "title": "Frist: Feedback der Geschäftsführung",
+                "description": "Rückmeldung der Geschäftsführung der Mandantin erwartet.",
+                "timestamp": "2025-11-05T12:00:00+01:00",
+                "status": "ausstehend"
+              },
+              {
+                "id": "evt-04",
+                "type": "activity",
+                "title": "Teams-Call mit Mandantin",
+                "description": "Besprechung der offenen Punkte in Kapitel 4 (Gewährleistung).",
+                "timestamp": "2025-10-31T11:00:00+01:00",
+                "duration": "45 Minuten"
+              },
+              {
+                "id": "evt-05",
+                "type": "document",
+                "title": "Kommentierter Vertragsanhang",
+                "description": "Mandantin hat Anhang A mit Kommentaren versehen zurückgesandt.",
+                "timestamp": "2025-10-28T08:25:00+02:00",
+                "author": "Müller GmbH"
+              }
+            ]
+          },
+          {
+            "caseNumber": "A-2024-017",
+            "title": "Arbeitsrechtliche Beratung Schmidt",
+            "client": "Eva Schmidt",
+            "status": "Warten auf Rückmeldung",
+            "priority": "Mittel",
+            "practiceArea": "Arbeitsrecht",
+            "responsible": "RAin Julia Reuter",
+            "lastUpdated": "2025-10-30T10:15:00+01:00",
+            "tags": ["Vergleich", "Kündigung"],
+            "nextSteps": [
+              "Entwurf Vergleichsangebot finalisieren",
+              "Unterlagen für Gütetermin vorbereiten"
+            ],
+            "timeline": [
+              {
+                "id": "evt-06",
+                "type": "deadline",
+                "title": "Frist: Stellungnahme der Gegenseite",
+                "description": "Gegenseite zugesagte Stellungnahme erwartet.",
+                "timestamp": "2025-11-07T18:00:00+01:00",
+                "status": "offen"
+              },
+              {
+                "id": "evt-07",
+                "type": "note",
+                "title": "Mandantenfeedback",
+                "description": "Mandantin stimmt vorgeschlagenem Vergleichsbetrag zu.",
+                "timestamp": "2025-10-29T13:40:00+01:00",
+                "author": "RAin Julia Reuter"
+              },
+              {
+                "id": "evt-08",
+                "type": "activity",
+                "title": "Arbeitsgericht – Gütetermin terminiert",
+                "description": "Terminbestätigung vom Gericht erhalten.",
+                "timestamp": "2025-10-27T09:05:00+02:00",
+                "duration": "15 Minuten"
+              }
+            ]
+          }
+        ]
+      }
+    </script>
+
+    <script src="assets/js/app.js" type="module"></script>
+    <script src="assets/js/case-detail.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated case-detail page with sidebar metadata and a filterable timeline for each dossier
- introduce a case-detail JavaScript module that renders timeline entries and works with the global error overlay
- extend the case directory to link to the new detail view and refresh the shared styles
- update the ToDo tracker to mark the timeline feature as completed

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_690a0851dc9083209e3336493a81e6e3