### PR TITLE
Add multi-step mandate wizard

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -28,8 +28,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 4. **Akten-Detailseite & Timeline** – Baue eine Detailseite, die die Historie eines Akts als chronologische Timeline darstellt (Dokumente, Notizen, Fristen, Aktivitäten). Nutze ein responsives Layout mit Seitenleiste für Akteninfos.
    Status: ✅ erledigt – 2025-11-04
 
-5. **Mandats-Wizard (mehrstufig)** – Erstelle einen Wizard mit mehreren Schritten zur Mandatsanlage (Klientendaten → Gegner → Akteninhalt → Abschluss). Jeder Schritt soll eigene Validierung und Fortschrittsanzeige besitzen.  
-   Status: ⬜
+5. **Mandats-Wizard (mehrstufig)** – Erstelle einen Wizard mit mehreren Schritten zur Mandatsanlage (Klientendaten → Gegner → Akteninhalt → Abschluss). Jeder Schritt soll eigene Validierung und Fortschrittsanzeige besitzen.
+   Status: ✅ erledigt – 2025-11-04
 
 6. **Dokumentenverwaltung (DMS-Mock)** – Implementiere eine Drag-&-Drop-Zone für Datei-Uploads mit Upload-Liste, Vorschau und Delete-Button. Es genügt ein Mock-Verhalten (kein echter Upload).  
    Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -58,6 +58,17 @@ body {
   font-size: clamp(1.5rem, 3vw, 1.9rem);
 }
 
+.welcome-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.welcome-actions .btn {
+  text-decoration: none;
+}
+
 .btn {
   display: inline-flex;
   align-items: center;
@@ -760,3 +771,256 @@ body {
   }
 }
 
+
+.btn-success {
+  background: #16a34a;
+  color: #fff;
+  border-color: rgba(22, 163, 74, 0.6);
+  box-shadow: 0 10px 24px rgba(22, 163, 74, 0.35);
+}
+
+.btn-success:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 32px rgba(22, 163, 74, 0.4);
+}
+
+.wizard-breadcrumb {
+  width: min(960px, 100%);
+  align-self: flex-start;
+}
+
+.wizard-breadcrumb__link {
+  color: #1f3c88;
+  font-weight: 600;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.wizard-breadcrumb__link:hover,
+.wizard-breadcrumb__link:focus-visible {
+  text-decoration: underline;
+}
+
+.wizard-card {
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.wizard-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.wizard-card__description {
+  margin: 0;
+  color: #4b5563;
+}
+
+.wizard-progress {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.wizard-progress__step {
+  position: relative;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(47, 116, 192, 0.12);
+  color: #1f3c88;
+  font-weight: 600;
+  text-align: center;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.wizard-progress__step--current {
+  background: linear-gradient(135deg, #2f74c0, #1f3c88);
+  color: #fff;
+  box-shadow: 0 12px 28px rgba(47, 116, 192, 0.3);
+}
+
+.wizard-progress__step--completed {
+  background: rgba(22, 163, 74, 0.15);
+  color: #166534;
+}
+
+.wizard-progress__step--upcoming {
+  opacity: 0.75;
+}
+
+.wizard-form {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.wizard-fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.wizard-step__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.35rem;
+}
+
+.wizard-step__hint {
+  margin: 0 0 1.5rem;
+  color: #4b5563;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-field label,
+.form-field legend {
+  font-weight: 600;
+  color: #1f2933;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  padding: 0.75rem 0.9rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  font-family: inherit;
+}
+
+.form-field textarea {
+  resize: vertical;
+}
+
+.form-field input:focus,
+.form-field select:focus,
+.form-field textarea:focus {
+  border-color: rgba(47, 116, 192, 0.45);
+  box-shadow: 0 0 0 4px rgba(47, 116, 192, 0.15);
+  outline: none;
+}
+
+.form-field--inline legend {
+  margin-bottom: 0.5rem;
+}
+
+.checkbox-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.5rem 1rem;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: #1f2933;
+}
+
+.checkbox input {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 6px;
+  border: 1px solid rgba(15, 23, 42, 0.25);
+}
+
+.field-error {
+  min-height: 1.1rem;
+  font-size: 0.85rem;
+  color: #b91c1c;
+}
+
+.is-invalid {
+  border-color: rgba(185, 28, 28, 0.65) !important;
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.3);
+}
+
+.wizard-navigation {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.wizard-summary {
+  display: grid;
+  gap: 1rem;
+  background: rgba(47, 116, 192, 0.05);
+  border: 1px solid rgba(47, 116, 192, 0.15);
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.summary-grid div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.summary-grid dt {
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.summary-grid dd {
+  margin: 0;
+}
+
+.summary-grid .summary-wide {
+  grid-column: 1 / -1;
+}
+
+.summary-list {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.wizard-success {
+  background: rgba(22, 163, 74, 0.12);
+  border: 1px solid rgba(22, 163, 74, 0.35);
+  border-radius: 16px;
+  padding: 1.75rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (max-width: 720px) {
+  .wizard-progress {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .wizard-navigation {
+    flex-direction: column;
+  }
+
+  .wizard-navigation .btn {
+    width: 100%;
+  }
+}

--- a/assets/js/mandate-wizard.js
+++ b/assets/js/mandate-wizard.js
@@ -1,0 +1,618 @@
+class GlobalErrorOverlay {
+  constructor(root) {
+    this.root = root;
+    this.messageEl = root.querySelector('#error-overlay-message');
+    this.detailsEl = root.querySelector('#error-overlay-details');
+    this.dismissButtons = root.querySelectorAll('[data-error-action="dismiss"]');
+    this.reloadButton = root.querySelector('[data-error-action="reload"]');
+    this.isVisible = false;
+
+    this.dismissButtons.forEach((btn) =>
+      btn.addEventListener('click', () => this.hide())
+    );
+
+    if (this.reloadButton) {
+      this.reloadButton.addEventListener('click', () => {
+        window.location.reload();
+      });
+    }
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && this.isVisible) {
+        this.hide();
+      }
+    });
+  }
+
+  show({ title, message, details }) {
+    if (title) {
+      const titleEl = this.root.querySelector('#error-overlay-title');
+      if (titleEl) {
+        titleEl.textContent = title;
+      }
+    }
+
+    if (this.messageEl) {
+      this.messageEl.textContent =
+        message ?? 'Ein unbekannter Fehler ist aufgetreten.';
+    }
+
+    if (this.detailsEl) {
+      if (details) {
+        this.detailsEl.textContent = details;
+        this.detailsEl.parentElement?.removeAttribute('hidden');
+      } else {
+        this.detailsEl.textContent = '';
+        this.detailsEl.parentElement?.setAttribute('hidden', '');
+      }
+    }
+
+    this.root.removeAttribute('hidden');
+    this.root.setAttribute('aria-hidden', 'false');
+    this.isVisible = true;
+  }
+
+  hide() {
+    this.root.setAttribute('hidden', '');
+    this.root.setAttribute('aria-hidden', 'true');
+    this.isVisible = false;
+  }
+}
+
+function formatErrorDetails(error) {
+  if (!error) return '';
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return [error.message, error.stack].filter(Boolean).join('\n');
+  }
+
+  try {
+    return JSON.stringify(error, null, 2);
+  } catch (jsonError) {
+    return String(error);
+  }
+}
+
+function initGlobalErrorHandling() {
+  const overlayRoot = document.getElementById('global-error-overlay');
+  if (!overlayRoot) {
+    console.warn('Global error overlay root element not found.');
+    return null;
+  }
+
+  const overlay = new GlobalErrorOverlay(overlayRoot);
+
+  const showFromEvent = (event) => {
+    const { error, reason, message, filename, lineno, colno } = event;
+    const detailSource = error ?? reason;
+    const formattedDetails = formatErrorDetails(detailSource);
+
+    const overlayTitle = 'Ein unerwarteter Fehler ist aufgetreten';
+    const overlayMessage =
+      typeof message === 'string'
+        ? message
+        : 'Bitte entschuldigen Sie die Umstände. Wir kümmern uns sofort darum.';
+
+    const meta = [];
+    if (filename) {
+      meta.push(`Datei: ${filename}`);
+    }
+    if (typeof lineno === 'number') {
+      meta.push(`Zeile: ${lineno}`);
+    }
+    if (typeof colno === 'number') {
+      meta.push(`Spalte: ${colno}`);
+    }
+
+    const details = [formattedDetails, meta.join(' | ')].filter(Boolean).join('\n\n');
+
+    overlay.show({ title: overlayTitle, message: overlayMessage, details });
+  };
+
+  window.addEventListener('error', (event) => {
+    event.preventDefault();
+    showFromEvent(event);
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    event.preventDefault();
+    showFromEvent(event);
+  });
+
+  window.addEventListener('verilex:error', (event) => {
+    const detail = event.detail ?? {};
+    overlay.show({
+      title: detail.title ?? 'Fehler',
+      message:
+        detail.message ??
+        'Es ist ein Problem aufgetreten. Bitte versuchen Sie es erneut.',
+      details: formatErrorDetails(detail.details),
+    });
+  });
+
+  return overlay;
+}
+
+const overlayInstance = initGlobalErrorHandling();
+
+function getSteps(form) {
+  return Array.from(form.querySelectorAll('.wizard-step'));
+}
+
+function findStep(form, index) {
+  return form.querySelector(`.wizard-step[data-step="${index}"]`);
+}
+
+function updateProgressIndicator(container, activeIndex, maxIndex) {
+  const steps = Array.from(container.querySelectorAll('[data-progress-step]'));
+  steps.forEach((stepEl) => {
+    const stepIndex = Number.parseInt(stepEl.dataset.progressStep ?? '0', 10);
+    stepEl.classList.toggle('wizard-progress__step--current', stepIndex === activeIndex);
+    stepEl.classList.toggle('wizard-progress__step--completed', stepIndex < activeIndex);
+    stepEl.classList.toggle('wizard-progress__step--upcoming', stepIndex > activeIndex);
+    if (stepIndex === activeIndex) {
+      stepEl.setAttribute('aria-current', 'step');
+    } else {
+      stepEl.removeAttribute('aria-current');
+    }
+  });
+
+  container.setAttribute(
+    'aria-label',
+    `Fortschritt Mandatsanlage: Schritt ${activeIndex} von ${maxIndex}`
+  );
+}
+
+function collectFormData(form) {
+  const formData = new FormData(form);
+  const data = {};
+
+  for (const [key, value] of formData.entries()) {
+    if (key === 'documents') {
+      continue;
+    }
+
+    data[key] = typeof value === 'string' ? value.trim() : value;
+  }
+
+  const documentSelections = formData.getAll('documents');
+  if (documentSelections.length > 0) {
+    data.documents = documentSelections;
+  } else {
+    delete data.documents;
+  }
+
+  return data;
+}
+
+function formatDocumentLabel(value) {
+  const labels = {
+    vertrag: 'Vertragsunterlagen',
+    korrespondenz: 'Schriftverkehr',
+    beweise: 'Beweisstücke',
+    aktennotizen: 'Interne Aktennotizen',
+  };
+  return labels[value] ?? value;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function formatDisplay(value, fallback = '–') {
+  if (value == null) {
+    return escapeHtml(fallback);
+  }
+
+  const trimmed = typeof value === 'string' ? value.trim() : value;
+  if (trimmed === '') {
+    return escapeHtml(fallback);
+  }
+
+  return escapeHtml(trimmed);
+}
+
+function formatMultiline(value, fallback = 'Keine Notizen hinterlegt.') {
+  const display = formatDisplay(value, fallback);
+  return display.replace(/\n/g, '<br />');
+}
+
+function renderSummary(container, data) {
+  const documentList = (data.documents ?? [])
+    .map((doc) => `<li>${escapeHtml(formatDocumentLabel(doc))}</li>`)
+    .join('');
+
+  container.innerHTML = `
+    <dl class="summary-grid">
+      <div>
+        <dt>Mandatsnummer</dt>
+        <dd>${formatDisplay(data.mandateNumber)}</dd>
+      </div>
+      <div>
+        <dt>Mandant*in</dt>
+        <dd>${formatDisplay(data.clientName)}</dd>
+      </div>
+      <div>
+        <dt>E-Mail</dt>
+        <dd>${formatDisplay(data.contactEmail)}</dd>
+      </div>
+      <div>
+        <dt>Telefon</dt>
+        <dd>${formatDisplay(data.contactPhone)}</dd>
+      </div>
+      <div>
+        <dt>Rechtsgebiet</dt>
+        <dd>${formatDisplay(formatLabel(data.practiceArea))}</dd>
+      </div>
+      <div>
+        <dt>Verantwortliche Person</dt>
+        <dd>${formatDisplay(data.responsibleLawyer)}</dd>
+      </div>
+      <div>
+        <dt>Gegenpartei</dt>
+        <dd>${formatDisplay(data.opponentName)}</dd>
+      </div>
+      <div>
+        <dt>Kontakt Gegenpartei</dt>
+        <dd>${formatDisplay(data.opponentContact)}</dd>
+      </div>
+      <div class="summary-wide">
+        <dt>Notizen</dt>
+        <dd>${formatMultiline(data.opponentNotes)}</dd>
+      </div>
+      <div class="summary-wide">
+        <dt>Akteninhalt</dt>
+        <dd>${formatMultiline(data.matterSummary, '–')}</dd>
+      </div>
+      <div>
+        <dt>Dringlichkeit</dt>
+        <dd>${formatDisplay(formatLabel(data.urgency))}</dd>
+      </div>
+      <div>
+        <dt>Erste Frist</dt>
+        <dd>${formatDisplay(formatDate(data.initialDeadline))}</dd>
+      </div>
+      <div class="summary-wide">
+        <dt>Dokumente</dt>
+        <dd>
+          ${
+            documentList
+              ? `<ul class="summary-list">${documentList}</ul>`
+              : 'Noch keine Dokumente ausgewählt.'
+          }
+        </dd>
+      </div>
+    </dl>
+  `;
+}
+
+function formatLabel(value) {
+  if (!value) return '–';
+  const labels = {
+    arbeitsrecht: 'Arbeitsrecht',
+    gesellschaftsrecht: 'Gesellschaftsrecht',
+    familienrecht: 'Familienrecht',
+    strafrecht: 'Strafrecht',
+    zivilrecht: 'Zivilrecht',
+    hoch: 'Hoch',
+    mittel: 'Mittel',
+    niedrig: 'Niedrig',
+  };
+  return labels[value] ?? value;
+}
+
+function formatDate(value) {
+  if (!value) return '–';
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '–';
+    }
+    return new Intl.DateTimeFormat('de-DE', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    }).format(date);
+  } catch (error) {
+    console.error('Failed to format date', error);
+    overlayInstance?.show?.({
+      title: 'Fehler bei der Datumsformatierung',
+      message: 'Das eingegebene Datum konnte nicht verarbeitet werden.',
+      details: error,
+    });
+    return value;
+  }
+}
+
+function resetErrors(step) {
+  step.querySelectorAll('.field-error').forEach((el) => {
+    el.textContent = '';
+  });
+
+  step
+    .querySelectorAll('.is-invalid')
+    .forEach((field) => {
+      field.classList.remove('is-invalid');
+      field.removeAttribute('aria-invalid');
+    });
+}
+
+function validateStep(step) {
+  resetErrors(step);
+
+  const inputs = step.querySelectorAll('input, select, textarea');
+  let isValid = true;
+
+  inputs.forEach((input) => {
+    const errorElementId = input.getAttribute('aria-describedby');
+    const errorElement = errorElementId
+      ? step.querySelector(`#${CSS.escape(errorElementId)}`)
+      : null;
+
+    input.classList.remove('is-invalid');
+
+    if (input.hasAttribute('required') && !input.value.trim()) {
+      isValid = false;
+      input.classList.add('is-invalid');
+      input.setAttribute('aria-invalid', 'true');
+      if (errorElement) {
+        errorElement.textContent = 'Dieses Feld ist erforderlich.';
+      }
+      return;
+    }
+
+    if (input.type === 'email' && input.value) {
+      const emailPattern = /\S+@\S+\.\S+/;
+      if (!emailPattern.test(input.value)) {
+        isValid = false;
+        input.classList.add('is-invalid');
+        input.setAttribute('aria-invalid', 'true');
+        if (errorElement) {
+          errorElement.textContent = 'Bitte geben Sie eine gültige E-Mail-Adresse an.';
+        }
+        return;
+      }
+    }
+
+    if (input.type === 'tel' && input.value) {
+      const telPattern = /^[0-9+()\/\-\s]{6,}$/;
+      if (!telPattern.test(input.value)) {
+        isValid = false;
+        input.classList.add('is-invalid');
+        input.setAttribute('aria-invalid', 'true');
+        if (errorElement) {
+          errorElement.textContent = 'Bitte geben Sie eine gültige Telefonnummer ein.';
+        }
+      }
+    }
+  });
+
+  if (step.dataset.step === '4') {
+    const confirmation = step.querySelector('#terms-confirmation');
+    const errorElement = step.querySelector('#terms-confirmation-error');
+    if (confirmation && !confirmation.checked) {
+      isValid = false;
+      confirmation.classList.add('is-invalid');
+      confirmation.setAttribute('aria-invalid', 'true');
+      if (errorElement) {
+        errorElement.textContent = 'Bitte bestätigen Sie die Angaben.';
+      }
+    }
+  }
+
+  return isValid;
+}
+
+function toggleStepVisibility(steps, activeIndex) {
+  steps.forEach((step) => {
+    const stepIndex = Number.parseInt(step.dataset.step ?? '0', 10);
+    if (stepIndex === activeIndex) {
+      step.removeAttribute('hidden');
+    } else {
+      step.setAttribute('hidden', '');
+    }
+  });
+}
+
+function updateNavigationButtons({ prevBtn, nextBtn, submitBtn }, activeIndex, maxIndex) {
+  prevBtn.disabled = activeIndex === 1;
+  nextBtn.hidden = activeIndex === maxIndex;
+  submitBtn.hidden = activeIndex !== maxIndex;
+}
+
+function initWizard() {
+  const form = document.getElementById('mandate-form');
+  if (!form) {
+    return;
+  }
+
+  const steps = getSteps(form);
+  const maxIndex = steps.length;
+  let activeIndex = 1;
+  let formState = {};
+
+  const progress = document.querySelector('.wizard-progress');
+  const summaryContainer = document.getElementById('wizard-summary');
+  const successMessage = document.getElementById('wizard-success');
+  const resetButton = document.getElementById('wizard-reset');
+
+  const prevBtn = document.getElementById('wizard-prev');
+  const nextBtn = document.getElementById('wizard-next');
+  const submitBtn = document.getElementById('wizard-submit');
+
+  if (!progress || !prevBtn || !nextBtn || !submitBtn || !summaryContainer) {
+    console.error('Wizard initialisation failed due to missing elements.');
+    overlayInstance?.show?.({
+      title: 'Wizard konnte nicht geladen werden',
+      message: 'Bestimmte Elemente wurden nicht gefunden.',
+    });
+    return;
+  }
+
+  const showStep = (index) => {
+    activeIndex = index;
+    toggleStepVisibility(steps, activeIndex);
+    updateProgressIndicator(progress, activeIndex, maxIndex);
+    updateNavigationButtons({ prevBtn, nextBtn, submitBtn }, activeIndex, maxIndex);
+
+    const stepHeading = steps[activeIndex - 1]?.querySelector('.wizard-step__title');
+    if (stepHeading) {
+      stepHeading.focus?.();
+    }
+
+    if (activeIndex === maxIndex) {
+      formState = collectFormData(form);
+      renderSummary(summaryContainer, formState);
+    }
+  };
+
+  const goToNextStep = () => {
+    const currentStep = findStep(form, activeIndex);
+    if (!currentStep) {
+      return;
+    }
+
+    if (!validateStep(currentStep)) {
+      const firstInvalid = currentStep.querySelector('.is-invalid');
+      firstInvalid?.focus?.();
+      return;
+    }
+
+    if (activeIndex < maxIndex) {
+      showStep(activeIndex + 1);
+    }
+  };
+
+  const goToPreviousStep = () => {
+    if (activeIndex > 1) {
+      showStep(activeIndex - 1);
+    }
+  };
+
+  nextBtn.addEventListener('click', goToNextStep);
+  prevBtn.addEventListener('click', goToPreviousStep);
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const currentStep = findStep(form, activeIndex);
+    if (!currentStep) {
+      return;
+    }
+
+    if (!validateStep(currentStep)) {
+      const firstInvalid = currentStep.querySelector('.is-invalid');
+      firstInvalid?.focus?.();
+      return;
+    }
+
+    formState = collectFormData(form);
+    renderSummary(summaryContainer, formState);
+
+    form.setAttribute('hidden', '');
+    successMessage?.removeAttribute('hidden');
+    successMessage?.focus?.();
+  });
+
+  resetButton?.addEventListener('click', () => {
+    form.reset();
+    form.removeAttribute('hidden');
+    successMessage?.setAttribute('hidden', '');
+    form.querySelectorAll('.field-error').forEach((el) => {
+      el.textContent = '';
+    });
+    form
+      .querySelectorAll('.is-invalid')
+      .forEach((el) => {
+        el.classList.remove('is-invalid');
+        el.removeAttribute('aria-invalid');
+      });
+    summaryContainer.innerHTML = '';
+    formState = {};
+    showStep(1);
+  });
+
+  const handleFieldFeedback = (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement)) {
+      return;
+    }
+
+    const errorElementId = target.getAttribute('aria-describedby');
+    if (!errorElementId) {
+      return;
+    }
+
+    const errorElement = document.getElementById(errorElementId);
+    if (!errorElement || !target.classList.contains('is-invalid')) {
+      return;
+    }
+
+    if (target instanceof HTMLInputElement && target.type === 'checkbox') {
+      if (target.checked) {
+        target.classList.remove('is-invalid');
+        target.removeAttribute('aria-invalid');
+        errorElement.textContent = '';
+      }
+      return;
+    }
+
+    if (target.type === 'email' && target.value) {
+      const emailPattern = /\S+@\S+\.\S+/;
+      if (emailPattern.test(target.value)) {
+        target.classList.remove('is-invalid');
+        target.removeAttribute('aria-invalid');
+        errorElement.textContent = '';
+      }
+      return;
+    }
+
+    if (target.type === 'tel' && target.value) {
+      const telPattern = /^[0-9+()\/\-\s]{6,}$/;
+      if (telPattern.test(target.value)) {
+        target.classList.remove('is-invalid');
+        target.removeAttribute('aria-invalid');
+        errorElement.textContent = '';
+      }
+      return;
+    }
+
+    if (target instanceof HTMLSelectElement && target.value) {
+      target.classList.remove('is-invalid');
+      target.removeAttribute('aria-invalid');
+      errorElement.textContent = '';
+      return;
+    }
+
+    if (target.value.trim()) {
+      target.classList.remove('is-invalid');
+      target.removeAttribute('aria-invalid');
+      errorElement.textContent = '';
+    }
+  };
+
+  form.addEventListener('input', handleFieldFeedback);
+  form.addEventListener('change', handleFieldFeedback);
+
+  showStep(1);
+}
+
+try {
+  initWizard();
+} catch (error) {
+  console.error('Wizard initialisation failed', error);
+  overlayInstance?.show?.({
+    title: 'Unerwarteter Fehler',
+    message: 'Der Mandats-Wizard konnte nicht geladen werden.',
+    details: error,
+  });
+}

--- a/index.html
+++ b/index.html
@@ -20,9 +20,12 @@
           <code>ToDo.md</code> erweitert. Aktuell ist ein globales Fehler-Overlay
           aktiv, das Ausnahmesituationen für Nutzer:innen sichtbar macht.
         </p>
-        <button type="button" id="trigger-demo-error" class="btn btn-primary">
-          Demo-Fehler auslösen
-        </button>
+        <div class="welcome-actions">
+          <button type="button" id="trigger-demo-error" class="btn btn-secondary">
+            Demo-Fehler auslösen
+          </button>
+          <a class="btn btn-primary" href="mandate-wizard.html">Mandats-Wizard starten</a>
+        </div>
       </section>
 
       <section class="case-directory" aria-labelledby="case-directory-title">

--- a/mandate-wizard.html
+++ b/mandate-wizard.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Mandats-Wizard</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>VeriLex Demo</h1>
+      <p class="app-subtitle">Mandatsanlage in vier Schritten</p>
+    </header>
+
+    <main class="app-main" aria-live="polite">
+      <nav class="wizard-breadcrumb" aria-label="Navigation">
+        <a class="wizard-breadcrumb__link" href="index.html">&larr; Zur Übersicht</a>
+      </nav>
+
+      <section class="app-card wizard-card" aria-labelledby="wizard-title">
+        <header class="wizard-card__header">
+          <h2 id="wizard-title">Mandatsanlage</h2>
+          <p id="wizard-description" class="wizard-card__description">
+            Erfassen Sie die erforderlichen Informationen Schritt für Schritt. Alle Eingaben lassen sich vor dem Abschluss prüfen und anpassen.
+          </p>
+        </header>
+
+        <ol class="wizard-progress" role="list" aria-label="Fortschritt Mandatsanlage">
+          <li class="wizard-progress__step" data-progress-step="1" role="listitem">
+            <span class="wizard-progress__label">Klientendaten</span>
+          </li>
+          <li class="wizard-progress__step" data-progress-step="2" role="listitem">
+            <span class="wizard-progress__label">Gegner</span>
+          </li>
+          <li class="wizard-progress__step" data-progress-step="3" role="listitem">
+            <span class="wizard-progress__label">Akteninhalt</span>
+          </li>
+          <li class="wizard-progress__step" data-progress-step="4" role="listitem">
+            <span class="wizard-progress__label">Abschluss</span>
+          </li>
+        </ol>
+
+        <form id="mandate-form" class="wizard-form" novalidate aria-describedby="wizard-description">
+          <section class="wizard-step" data-step="1" aria-label="Klientendaten">
+            <fieldset class="wizard-fieldset">
+              <legend class="wizard-step__title" tabindex="-1">Schritt 1: Klientendaten</legend>
+              <p class="wizard-step__hint">Alle Pflichtfelder sind mit einem Sternchen gekennzeichnet.</p>
+
+              <div class="form-grid">
+                <div class="form-field">
+                  <label for="mandate-number">Mandatsnummer *</label>
+                  <input
+                    id="mandate-number"
+                    name="mandateNumber"
+                    type="text"
+                    inputmode="text"
+                    autocomplete="off"
+                    required
+                    maxlength="32"
+                    aria-describedby="mandate-number-error"
+                  />
+                  <p id="mandate-number-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="client-name">Mandant*in *</label>
+                  <input
+                    id="client-name"
+                    name="clientName"
+                    type="text"
+                    autocomplete="organization"
+                    required
+                    maxlength="80"
+                    aria-describedby="client-name-error"
+                  />
+                  <p id="client-name-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="contact-email">E-Mail *</label>
+                  <input
+                    id="contact-email"
+                    name="contactEmail"
+                    type="email"
+                    autocomplete="email"
+                    required
+                    maxlength="120"
+                    aria-describedby="contact-email-error"
+                  />
+                  <p id="contact-email-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="contact-phone">Telefon</label>
+                  <input
+                    id="contact-phone"
+                    name="contactPhone"
+                    type="tel"
+                    autocomplete="tel"
+                    pattern="^[0-9+()\/\-\s]{6,}$"
+                    maxlength="40"
+                    aria-describedby="contact-phone-error"
+                  />
+                  <p id="contact-phone-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+              </div>
+
+              <div class="form-grid">
+                <div class="form-field">
+                  <label for="practice-area">Rechtsgebiet *</label>
+                  <select
+                    id="practice-area"
+                    name="practiceArea"
+                    required
+                    aria-describedby="practice-area-error"
+                  >
+                    <option value="" disabled selected>Bitte wählen</option>
+                    <option value="arbeitsrecht">Arbeitsrecht</option>
+                    <option value="gesellschaftsrecht">Gesellschaftsrecht</option>
+                    <option value="familienrecht">Familienrecht</option>
+                    <option value="strafrecht">Strafrecht</option>
+                    <option value="zivilrecht">Zivilrecht</option>
+                  </select>
+                  <p id="practice-area-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="responsible-lawyer">Verantwortliche Person *</label>
+                  <input
+                    id="responsible-lawyer"
+                    name="responsibleLawyer"
+                    type="text"
+                    autocomplete="name"
+                    required
+                    maxlength="80"
+                    aria-describedby="responsible-lawyer-error"
+                  />
+                  <p id="responsible-lawyer-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+              </div>
+            </fieldset>
+          </section>
+
+          <section class="wizard-step" data-step="2" aria-label="Gegnerische Partei" hidden>
+            <fieldset class="wizard-fieldset">
+              <legend class="wizard-step__title" tabindex="-1">Schritt 2: Gegnerische Partei</legend>
+              <p class="wizard-step__hint">Erfassen Sie die wichtigsten Eckdaten zur gegnerischen Partei.</p>
+
+              <div class="form-grid">
+                <div class="form-field">
+                  <label for="opponent-name">Name der Gegenpartei *</label>
+                  <input
+                    id="opponent-name"
+                    name="opponentName"
+                    type="text"
+                    required
+                    maxlength="80"
+                    aria-describedby="opponent-name-error"
+                  />
+                  <p id="opponent-name-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="opponent-contact">Kontakt</label>
+                  <input
+                    id="opponent-contact"
+                    name="opponentContact"
+                    type="text"
+                    maxlength="120"
+                    aria-describedby="opponent-contact-error"
+                  />
+                  <p id="opponent-contact-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+              </div>
+
+              <div class="form-field">
+                <label for="opponent-notes">Notizen</label>
+                <textarea
+                  id="opponent-notes"
+                  name="opponentNotes"
+                  rows="4"
+                  maxlength="500"
+                  aria-describedby="opponent-notes-error"
+                ></textarea>
+                <p id="opponent-notes-error" class="field-error" role="status" aria-live="polite"></p>
+              </div>
+            </fieldset>
+          </section>
+
+          <section class="wizard-step" data-step="3" aria-label="Akteninhalt" hidden>
+            <fieldset class="wizard-fieldset">
+              <legend class="wizard-step__title" tabindex="-1">Schritt 3: Akteninhalt</legend>
+              <p class="wizard-step__hint">Beschreiben Sie den Sachverhalt und priorisieren Sie das Mandat.</p>
+
+              <div class="form-field">
+                <label for="matter-summary">Kurzbeschreibung *</label>
+                <textarea
+                  id="matter-summary"
+                  name="matterSummary"
+                  rows="5"
+                  required
+                  maxlength="1000"
+                  aria-describedby="matter-summary-error"
+                ></textarea>
+                <p id="matter-summary-error" class="field-error" role="status" aria-live="polite"></p>
+              </div>
+
+              <div class="form-grid">
+                <div class="form-field">
+                  <label for="urgency-level">Dringlichkeit *</label>
+                  <select
+                    id="urgency-level"
+                    name="urgency"
+                    required
+                    aria-describedby="urgency-level-error"
+                  >
+                    <option value="" disabled selected>Bitte wählen</option>
+                    <option value="hoch">Hoch</option>
+                    <option value="mittel">Mittel</option>
+                    <option value="niedrig">Niedrig</option>
+                  </select>
+                  <p id="urgency-level-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="initial-deadline">Erste Frist</label>
+                  <input
+                    id="initial-deadline"
+                    name="initialDeadline"
+                    type="date"
+                    aria-describedby="initial-deadline-error"
+                  />
+                  <p id="initial-deadline-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+              </div>
+
+              <fieldset class="form-field form-field--inline">
+                <legend>Benötigte Dokumente</legend>
+                <div class="checkbox-group">
+                  <label class="checkbox">
+                    <input type="checkbox" name="documents" value="vertrag" /> Vertragsunterlagen
+                  </label>
+                  <label class="checkbox">
+                    <input type="checkbox" name="documents" value="korrespondenz" /> Schriftverkehr
+                  </label>
+                  <label class="checkbox">
+                    <input type="checkbox" name="documents" value="beweise" /> Beweisstücke
+                  </label>
+                  <label class="checkbox">
+                    <input type="checkbox" name="documents" value="aktennotizen" /> Interne Aktennotizen
+                  </label>
+                </div>
+              </fieldset>
+            </fieldset>
+          </section>
+
+          <section class="wizard-step" data-step="4" aria-label="Zusammenfassung" hidden>
+            <fieldset class="wizard-fieldset">
+              <legend class="wizard-step__title" tabindex="-1">Schritt 4: Abschluss</legend>
+              <p class="wizard-step__hint">Prüfen Sie die Angaben und bestätigen Sie die Mandatsanlage.</p>
+
+              <div id="wizard-summary" class="wizard-summary" role="status" aria-live="polite"></div>
+
+              <div class="form-field">
+                <label class="checkbox">
+                  <input id="terms-confirmation" type="checkbox" required aria-describedby="terms-confirmation-error" />
+                  Ich bestätige, dass alle Angaben geprüft wurden.
+                </label>
+                <p id="terms-confirmation-error" class="field-error" role="status" aria-live="polite"></p>
+              </div>
+            </fieldset>
+          </section>
+
+          <div class="wizard-navigation" role="group" aria-label="Wizard-Steuerung">
+            <button type="button" class="btn btn-secondary" id="wizard-prev" data-action="prev" disabled>
+              Zurück
+            </button>
+            <button type="button" class="btn btn-primary" id="wizard-next" data-action="next">
+              Weiter
+            </button>
+            <button type="submit" class="btn btn-success" id="wizard-submit" data-action="submit" hidden>
+              Mandat anlegen
+            </button>
+          </div>
+        </form>
+
+        <div id="wizard-success" class="wizard-success" role="alert" hidden tabindex="-1">
+          <h3>Mandat erfolgreich vorbereitet</h3>
+          <p>
+            Die Daten wurden gespeichert. Als nächstes kann das Team die Akte freigeben oder weitere Dokumente anfordern.
+          </p>
+          <button type="button" class="btn" id="wizard-reset">Neues Mandat erfassen</button>
+        </div>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details" hidden>
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">
+            Seite neu laden
+          </button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">
+            Schließen
+          </button>
+        </footer>
+      </div>
+    </div>
+
+    <script src="assets/js/mandate-wizard.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated mandate-wizard page with a four-step client intake flow and validation
- implement JavaScript controller for wizard navigation, form validation, summary rendering, and error handling
- extend shared styles and landing page to link to the wizard and polish button layout
- update the task list to mark the mandate wizard feature as completed

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_690a0aede7388320b379fe0587dd2807