### PR TITLE
Add document management mock uploads

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -31,8 +31,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 5. **Mandats-Wizard (mehrstufig)** – Erstelle einen Wizard mit mehreren Schritten zur Mandatsanlage (Klientendaten → Gegner → Akteninhalt → Abschluss). Jeder Schritt soll eigene Validierung und Fortschrittsanzeige besitzen.
    Status: ✅ erledigt – 2025-11-04
 
-6. **Dokumentenverwaltung (DMS-Mock)** – Implementiere eine Drag-&-Drop-Zone für Datei-Uploads mit Upload-Liste, Vorschau und Delete-Button. Es genügt ein Mock-Verhalten (kein echter Upload).  
-   Status: ⬜
+6. **Dokumentenverwaltung (DMS-Mock)** – Implementiere eine Drag-&-Drop-Zone für Datei-Uploads mit Upload-Liste, Vorschau und Delete-Button. Es genügt ein Mock-Verhalten (kein echter Upload).
+   Status: ✅ erledigt – 2025-11-04
 
 7. **Dokument-Viewer** – Baue ein modales Fenster zum Anzeigen von PDF-Dokumenten (z. B. über eingebettetes `<iframe>`).  
    Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -147,6 +147,237 @@ body {
   color: #4b5563;
 }
 
+.document-manager-main {
+  width: min(1100px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.document-manager__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.document-manager__description {
+  margin: 0;
+  color: #4b5563;
+  max-width: 60ch;
+}
+
+.document-dropzone {
+  position: relative;
+  border: 2px dashed rgba(47, 116, 192, 0.45);
+  border-radius: 18px;
+  padding: clamp(1.5rem, 4vw, 2.75rem);
+  background: rgba(47, 116, 192, 0.06);
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+  transition: border-color 0.2s ease, background-color 0.2s ease,
+    transform 0.18s ease;
+}
+
+.document-dropzone:focus-visible {
+  outline: 3px solid rgba(47, 116, 192, 0.5);
+  outline-offset: 6px;
+}
+
+.document-dropzone--active {
+  border-color: #2f74c0;
+  background: rgba(47, 116, 192, 0.12);
+  transform: translateY(-2px);
+}
+
+.document-dropzone__icon {
+  width: clamp(48px, 10vw, 64px);
+  height: clamp(48px, 10vw, 64px);
+  margin: 0 auto;
+  display: grid;
+  place-items: center;
+  background: #2f74c0;
+  color: #fff;
+  border-radius: 16px;
+  font-size: clamp(1.6rem, 4vw, 2.2rem);
+  box-shadow: 0 15px 40px rgba(47, 116, 192, 0.3);
+}
+
+.document-dropzone__text {
+  margin: 0;
+  font-weight: 600;
+  font-size: clamp(1.05rem, 2.4vw, 1.25rem);
+  color: #1f3c88;
+}
+
+.document-dropzone__hint {
+  margin: 0;
+  color: #4b5563;
+}
+
+.document-dropzone__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.document-dropzone__file-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.document-list-section {
+  background: #fff;
+  border-radius: 18px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(31, 60, 136, 0.08);
+}
+
+.document-list__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.document-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.document-entry {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(31, 60, 136, 0.12);
+  border-radius: 14px;
+  background: linear-gradient(180deg, #ffffff, rgba(47, 116, 192, 0.04));
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+}
+
+.document-entry__preview {
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+  background: rgba(47, 116, 192, 0.1);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  position: relative;
+}
+
+.document-entry__preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.document-entry__meta {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.document-entry__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.document-entry__details {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.document-entry__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.document-badge {
+  background: rgba(31, 60, 136, 0.1);
+  color: #1f3c88;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.document-entry__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+.document-entry__action-btn {
+  background: transparent;
+  border: none;
+  color: #d11f3b;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.document-entry__action-btn:hover,
+.document-entry__action-btn:focus-visible {
+  background: rgba(209, 31, 59, 0.12);
+  color: #a4162b;
+  outline: none;
+}
+
+.document-empty-state {
+  margin: 0;
+  padding: 1.5rem;
+  text-align: center;
+  border: 1px dashed rgba(47, 116, 192, 0.35);
+  border-radius: 12px;
+  color: #4b5563;
+  background: rgba(47, 116, 192, 0.04);
+}
+
+.document-upload-summary {
+  margin: 0;
+  color: #1f3c88;
+  font-weight: 600;
+}
+
+.document-entry__preview-icon {
+  font-size: 1.5rem;
+  color: #2f74c0;
+}
+
+@media (max-width: 720px) {
+  .document-entry {
+    grid-template-columns: 1fr;
+    justify-items: stretch;
+    text-align: left;
+  }
+
+  .document-entry__actions {
+    align-items: stretch;
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+}
+
 .case-directory__search {
   display: flex;
   align-items: center;

--- a/assets/js/document-management.js
+++ b/assets/js/document-management.js
@@ -1,0 +1,381 @@
+import { overlayInstance } from './app.js';
+
+const dropzone = document.getElementById('document-dropzone');
+const selectFilesButton = document.getElementById('document-select-files');
+const fileInput = document.getElementById('document-file-input');
+const clearButton = document.getElementById('document-clear-all');
+const documentList = document.getElementById('document-list');
+const emptyState = document.getElementById('document-empty-state');
+const summaryEl = document.getElementById('document-upload-summary');
+const processingInfoEl = document.getElementById('document-processing-info');
+
+let documents = [];
+let seedDocuments = [];
+
+function createDocumentId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `doc-${Math.random().toString(16).slice(2, 10)}-${Date.now()}`;
+}
+
+function parseSeedData() {
+  const dataEl = document.getElementById('document-seed-data');
+  if (!dataEl) {
+    return [];
+  }
+
+  try {
+    const raw = dataEl.textContent ?? '[]';
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.map((entry) => ({
+        ...entry,
+        id: entry.id ?? createDocumentId(),
+      }));
+    }
+  } catch (error) {
+    console.error('Seed-Dokumente konnten nicht geladen werden.', error);
+    overlayInstance?.show?.({
+      title: 'Daten konnten nicht geladen werden',
+      message: 'Die initialen Dokumente stehen derzeit nicht zur Verfügung.',
+      details: error,
+    });
+  }
+
+  return [];
+}
+
+function formatFileSize(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return 'Größe unbekannt';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let size = bytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${size.toFixed(size >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function formatDate(value) {
+  if (!value) {
+    return 'Unbekanntes Datum';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('de-DE', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+function determineIconForMime(mimeType = '') {
+  if (mimeType.startsWith('image/')) {
+    return '🖼️';
+  }
+  if (mimeType === 'application/pdf') {
+    return '📄';
+  }
+  if (mimeType.includes('presentation')) {
+    return '📊';
+  }
+  if (mimeType.includes('sheet') || mimeType.includes('excel')) {
+    return '📈';
+  }
+  if (mimeType.includes('word') || mimeType.includes('text')) {
+    return '📝';
+  }
+  return '📁';
+}
+
+function renderDocument(doc) {
+  const listItem = document.createElement('li');
+  listItem.className = 'document-entry';
+  listItem.setAttribute('role', 'listitem');
+  listItem.dataset.documentId = doc.id;
+
+  const preview = document.createElement('div');
+  preview.className = 'document-entry__preview';
+
+  if (doc.previewUrl) {
+    const img = document.createElement('img');
+    img.src = doc.previewUrl;
+    img.alt = `Vorschau für ${doc.name}`;
+    preview.appendChild(img);
+  } else {
+    const icon = document.createElement('span');
+    icon.className = 'document-entry__preview-icon';
+    icon.textContent = determineIconForMime(doc.mimeType);
+    icon.setAttribute('aria-hidden', 'true');
+    preview.appendChild(icon);
+  }
+
+  const meta = document.createElement('div');
+  meta.className = 'document-entry__meta';
+
+  const title = document.createElement('p');
+  title.className = 'document-entry__title';
+  title.textContent = doc.name ?? 'Unbenanntes Dokument';
+
+  const details = document.createElement('p');
+  details.className = 'document-entry__details';
+  const sizeText = formatFileSize(doc.size);
+  const uploadedAtText = formatDate(doc.uploadedAt);
+  const uploadedBy = doc.uploadedBy ?? 'Unbekannte Person';
+  details.textContent = `${sizeText} • Hochgeladen am ${uploadedAtText} von ${uploadedBy}`;
+
+  const badges = document.createElement('div');
+  badges.className = 'document-entry__badges';
+
+  if (doc.status) {
+    const statusBadge = document.createElement('span');
+    statusBadge.className = 'document-badge';
+    statusBadge.textContent = doc.status;
+    badges.appendChild(statusBadge);
+  }
+
+  const tags = Array.isArray(doc.tags) ? doc.tags : [];
+  tags.forEach((tag) => {
+    const tagBadge = document.createElement('span');
+    tagBadge.className = 'document-badge';
+    tagBadge.textContent = tag;
+    badges.appendChild(tagBadge);
+  });
+
+  const notes = doc.notes ? document.createElement('p') : null;
+  if (notes) {
+    notes.className = 'document-entry__details';
+    notes.textContent = doc.notes;
+  }
+
+  meta.append(title, details, badges);
+  if (notes) {
+    meta.appendChild(notes);
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'document-entry__actions';
+
+  const removeButton = document.createElement('button');
+  removeButton.type = 'button';
+  removeButton.className = 'document-entry__action-btn';
+  removeButton.textContent = 'Entfernen';
+  removeButton.setAttribute('aria-label', `${doc.name} aus der Liste entfernen`);
+  removeButton.addEventListener('click', () => removeDocument(doc.id));
+
+  actions.appendChild(removeButton);
+
+  listItem.append(preview, meta, actions);
+
+  return listItem;
+}
+
+function renderDocumentList() {
+  if (!documentList || !emptyState || !summaryEl) {
+    return;
+  }
+
+  documentList.innerHTML = '';
+
+  if (documents.length === 0) {
+    emptyState.removeAttribute('hidden');
+    summaryEl.textContent = 'Keine Dokumente vorhanden.';
+    return;
+  }
+
+  emptyState.setAttribute('hidden', '');
+
+  const fragment = document.createDocumentFragment();
+  documents.forEach((doc) => {
+    fragment.appendChild(renderDocument(doc));
+  });
+
+  documentList.appendChild(fragment);
+
+  const totalSize = documents.reduce((sum, doc) => sum + (doc.size ?? 0), 0);
+  summaryEl.textContent = `${documents.length} Dokumente · Gesamtgröße ${formatFileSize(totalSize)}`;
+}
+
+function updateProcessingInfo(message) {
+  if (!processingInfoEl) {
+    return;
+  }
+
+  processingInfoEl.textContent = message ?? 'Bereit für neue Uploads.';
+}
+
+function removeDocument(id) {
+  documents = documents.filter((doc) => doc.id !== id);
+  renderDocumentList();
+  updateProcessingInfo('Dokument wurde entfernt.');
+}
+
+function resetDocuments() {
+  documents = seedDocuments.map((doc) => ({ ...doc }));
+  renderDocumentList();
+  updateProcessingInfo('Liste wurde auf den Demo-Ausgangszustand zurückgesetzt.');
+}
+
+function createDocumentFromFile(file) {
+  return {
+    id: createDocumentId(),
+    name: file.name ?? 'Unbenannt',
+    mimeType: file.type ?? 'application/octet-stream',
+    size: file.size ?? 0,
+    uploadedAt: new Date().toISOString(),
+    uploadedBy: 'Sie (Demo)',
+    status: 'Upload abgeschlossen (Mock)',
+    tags: [],
+    notes: 'Lokale Datei – keine Übertragung erfolgt.',
+    file,
+  };
+}
+
+function readPreviewForFile(doc) {
+  if (!doc.file || !doc.mimeType?.startsWith('image/')) {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(doc.file);
+  });
+}
+
+async function processFiles(fileList) {
+  const files = Array.from(fileList ?? []);
+  if (files.length === 0) {
+    updateProcessingInfo('Es wurden keine Dateien ausgewählt.');
+    return;
+  }
+
+  updateProcessingInfo(`${files.length} Datei(en) werden verarbeitet …`);
+
+  for (const file of files) {
+    const doc = createDocumentFromFile(file);
+    documents.unshift(doc);
+    renderDocumentList();
+
+    try {
+      const previewUrl = await readPreviewForFile(doc);
+      const target = documents.find((entry) => entry.id === doc.id);
+
+      if (target) {
+        if (previewUrl) {
+          target.previewUrl = previewUrl;
+        }
+        if (target.file) {
+          delete target.file;
+        }
+        if (previewUrl) {
+          renderDocumentList();
+        }
+      }
+    } catch (error) {
+      console.error('Vorschau konnte nicht erzeugt werden.', error);
+      overlayInstance?.show?.({
+        title: 'Vorschau nicht möglich',
+        message: `Für ${doc.name} konnte keine Vorschau erzeugt werden.`,
+        details: error,
+      });
+    }
+  }
+
+  updateProcessingInfo('Upload abgeschlossen. Die Liste wurde aktualisiert.');
+}
+
+function handleDrop(event) {
+  event.preventDefault();
+  if (!dropzone) {
+    return;
+  }
+  dropzone.classList.remove('document-dropzone--active');
+  if (event.dataTransfer?.files) {
+    processFiles(event.dataTransfer.files);
+  }
+}
+
+function handleDragEnter(event) {
+  event.preventDefault();
+  if (!dropzone) {
+    return;
+  }
+  dropzone.classList.add('document-dropzone--active');
+}
+
+function handleDragOver(event) {
+  event.preventDefault();
+  if (!dropzone) {
+    return;
+  }
+  event.dataTransfer.dropEffect = 'copy';
+}
+
+function handleDragLeave(event) {
+  if (!dropzone) {
+    return;
+  }
+
+  const nextTarget = event.relatedTarget;
+  if (!nextTarget || !dropzone.contains(nextTarget)) {
+    dropzone.classList.remove('document-dropzone--active');
+  }
+}
+
+function attachEventListeners() {
+  dropzone?.addEventListener('dragenter', handleDragEnter);
+  dropzone?.addEventListener('dragover', handleDragOver);
+  dropzone?.addEventListener('dragleave', handleDragLeave);
+  dropzone?.addEventListener('drop', handleDrop);
+
+  dropzone?.addEventListener('click', () => fileInput?.click?.());
+  dropzone?.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      fileInput?.click?.();
+    }
+  });
+
+  selectFilesButton?.addEventListener('click', () => fileInput?.click?.());
+
+  fileInput?.addEventListener('change', (event) => {
+    const target = event.currentTarget;
+    if (!(target instanceof HTMLInputElement) || !target.files) {
+      return;
+    }
+    processFiles(target.files);
+    target.value = '';
+  });
+
+  clearButton?.addEventListener('click', () => {
+    const confirmed = window.confirm(
+      'Möchten Sie die Liste wirklich zurücksetzen? Alle nicht gespeicherten Einträge gehen verloren.'
+    );
+    if (confirmed) {
+      resetDocuments();
+    }
+  });
+}
+
+function init() {
+  seedDocuments = parseSeedData();
+  documents = seedDocuments.map((doc) => ({ ...doc }));
+  renderDocumentList();
+  updateProcessingInfo('Bereit für neue Uploads.');
+  attachEventListeners();
+}
+
+init();

--- a/document-management.html
+++ b/document-management.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Dokumentenverwaltung</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>VeriLex Demo</h1>
+      <p class="app-subtitle">Dokumentenverwaltung (Mock)</p>
+    </header>
+
+    <main class="app-main document-manager-main" aria-live="polite">
+      <nav class="case-breadcrumb" aria-label="Brotkrumen">
+        <a class="case-breadcrumb__link" href="index.html">&larr; Zur Startseite</a>
+      </nav>
+
+      <section class="app-card" aria-labelledby="document-dropzone-title">
+        <header class="document-manager__header">
+          <h2 id="document-dropzone-title">Dateien hochladen &amp; verwalten</h2>
+          <p class="document-manager__description">
+            Laden Sie neue Dokumente per Drag &amp; Drop hoch, ergänzen Sie Notizen und behalten Sie einen
+            schnellen Überblick über alle hochgeladenen Dateien. Der Upload ist in dieser Demo rein
+            simuliert.
+          </p>
+        </header>
+
+        <div
+          id="document-dropzone"
+          class="document-dropzone"
+          role="button"
+          tabindex="0"
+          aria-describedby="document-dropzone-hint"
+          aria-label="Dateien hochladen"
+        >
+          <div class="document-dropzone__icon" aria-hidden="true">⬆</div>
+          <p class="document-dropzone__text">Dateien hierher ziehen oder auswählen</p>
+          <p id="document-dropzone-hint" class="document-dropzone__hint">
+            Unterstützt werden PDF, Bilder und gängige Office-Dokumente. Mehrere Dateien sind möglich.
+          </p>
+          <div class="document-dropzone__actions">
+            <button type="button" class="btn btn-primary" id="document-select-files">
+              Dateien auswählen
+            </button>
+            <button type="button" class="btn btn-secondary" id="document-clear-all">
+              Liste zurücksetzen
+            </button>
+          </div>
+          <input
+            type="file"
+            id="document-file-input"
+            class="document-dropzone__file-input"
+            multiple
+            aria-hidden="true"
+            tabindex="-1"
+          />
+        </div>
+      </section>
+
+      <section class="document-list-section" aria-labelledby="document-list-title">
+        <div class="document-list__header">
+          <div>
+            <h2 id="document-list-title">Hochgeladene Dokumente</h2>
+            <p class="document-upload-summary" id="document-upload-summary"></p>
+          </div>
+          <p id="document-processing-info" class="document-manager__description"></p>
+        </div>
+
+        <ul id="document-list" class="document-list" role="list"></ul>
+        <p id="document-empty-state" class="document-empty-state" hidden>
+          Noch wurden keine Dokumente hochgeladen. Nutzen Sie die Drag-&amp;-Drop-Zone, um die Liste zu
+          füllen.
+        </p>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details" hidden>
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">Seite neu laden</button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">Schließen</button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="application/json" id="document-seed-data">
+      [
+        {
+          "id": "doc-001",
+          "name": "Klageentwurf.pdf",
+          "mimeType": "application/pdf",
+          "size": 584312,
+          "uploadedAt": "2025-10-29T09:30:00+01:00",
+          "uploadedBy": "RAin Dr. Hannah Keller",
+          "status": "Entwurf – finale Prüfung läuft",
+          "tags": ["Klage", "Entwurf"],
+          "notes": "Vor Versand an Mandantin prüfen."
+        },
+        {
+          "id": "doc-002",
+          "name": "Beweisfoto_A1.jpg",
+          "mimeType": "image/jpeg",
+          "size": 341233,
+          "uploadedAt": "2025-10-20T16:12:00+02:00",
+          "uploadedBy": "Syndikus RA Tim Berger",
+          "status": "Freigegeben",
+          "tags": ["Beweis", "Bild"],
+          "notes": "Referenz für Abschnitt 4 des Schriftsatzes."
+        },
+        {
+          "id": "doc-003",
+          "name": "Vergleichsentwurf.docx",
+          "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "size": 214560,
+          "uploadedAt": "2025-10-05T11:04:00+02:00",
+          "uploadedBy": "RAin Dr. Hannah Keller",
+          "status": "Feedback des Mandanten erforderlich",
+          "tags": ["Vergleich", "ToDo"],
+          "notes": "Mandantenfeedback bis Ende KW45 einarbeiten."
+        }
+      ]
+    </script>
+
+    <script src="assets/js/document-management.js" type="module"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
             Demo-Fehler auslösen
           </button>
           <a class="btn btn-primary" href="mandate-wizard.html">Mandats-Wizard starten</a>
+          <a class="btn btn-secondary" href="document-management.html">Dokumentenverwaltung</a>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add a dedicated document-management page with drag-and-drop upload mock, seeded demo data, and accessibility-friendly layout
- implement client-side logic for processing uploads, generating previews, removing entries, and resetting to demo defaults
- extend shared styling, surface the new page in the welcome area, and update the ToDo list status

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690a0cfceeb483209286394b63c30369