### PR TITLE
Add PDF document viewer modal to document management page

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -34,8 +34,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 6. **Dokumentenverwaltung (DMS-Mock)** – Implementiere eine Drag-&-Drop-Zone für Datei-Uploads mit Upload-Liste, Vorschau und Delete-Button. Es genügt ein Mock-Verhalten (kein echter Upload).
    Status: ✅ erledigt – 2025-11-04
 
-7. **Dokument-Viewer** – Baue ein modales Fenster zum Anzeigen von PDF-Dokumenten (z. B. über eingebettetes `<iframe>`).  
-   Status: ⬜
+7. **Dokument-Viewer** – Baue ein modales Fenster zum Anzeigen von PDF-Dokumenten (z. B. über eingebettetes `<iframe>`).
+   Status: ✅ erledigt – 2025-11-04
 
 8. **Vorlagen-Assistent** – Füge ein einfaches Formular hinzu, mit dem Textbausteine oder Vorlagen angezeigt, angepasst und in das Dokument eingefügt werden können.  
    Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -324,8 +324,8 @@ body {
 
 .document-entry__action-btn {
   background: transparent;
-  border: none;
-  color: #d11f3b;
+  border: 1px solid transparent;
+  color: #1f3c88;
   font-weight: 600;
   cursor: pointer;
   display: inline-flex;
@@ -336,11 +336,36 @@ body {
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.document-entry__action-btn:hover,
 .document-entry__action-btn:focus-visible {
+  outline: 3px solid rgba(47, 116, 192, 0.4);
+  outline-offset: 2px;
+}
+
+.document-entry__action-btn--primary {
+  background: rgba(47, 116, 192, 0.12);
+  border-color: rgba(47, 116, 192, 0.35);
+  color: #1f3c88;
+}
+
+.document-entry__action-btn--primary:hover,
+.document-entry__action-btn--primary:focus-visible {
+  background: rgba(47, 116, 192, 0.22);
+  color: #163470;
+}
+
+.document-entry__action-btn--danger {
+  color: #d11f3b;
+}
+
+.document-entry__action-btn--danger:hover,
+.document-entry__action-btn--danger:focus-visible {
   background: rgba(209, 31, 59, 0.12);
   color: #a4162b;
-  outline: none;
+}
+
+.document-entry__action-btn[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .document-empty-state {
@@ -1253,5 +1278,116 @@ body {
 
   .wizard-navigation .btn {
     width: 100%;
+  }
+}
+
+.document-viewer[hidden] {
+  display: none !important;
+}
+
+.document-viewer {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 5vw, 3rem);
+}
+
+.document-viewer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(4px);
+}
+
+.document-viewer__dialog {
+  position: relative;
+  z-index: 1;
+  width: min(960px, 100%);
+  height: min(90vh, 720px);
+  background: #fff;
+  border-radius: 20px;
+  padding: clamp(1rem, 4vw, 1.75rem);
+  box-shadow: 0 25px 65px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+}
+
+.document-viewer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.document-viewer__header h2 {
+  margin: 0;
+  font-size: clamp(1.3rem, 2.5vw, 1.6rem);
+  color: #1f3c88;
+}
+
+.document-viewer__close {
+  background: transparent;
+  border: none;
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #475569;
+  border-radius: 50%;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: grid;
+  place-items: center;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.document-viewer__close:hover,
+.document-viewer__close:focus-visible {
+  background: rgba(47, 116, 192, 0.1);
+  color: #1f3c88;
+  outline: none;
+}
+
+.document-viewer__meta {
+  margin: 0 0 1rem;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.document-viewer__body {
+  flex: 1;
+  border-radius: 16px;
+  overflow: hidden;
+  background: rgba(241, 245, 249, 0.85);
+  position: relative;
+}
+
+.document-viewer__frame {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.document-viewer__fallback {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  text-align: center;
+  color: #1f2937;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+@media (max-width: 600px) {
+  .document-viewer__dialog {
+    height: min(90vh, 580px);
+  }
+
+  .document-viewer__meta {
+    font-size: 0.9rem;
   }
 }

--- a/assets/mock/verilex-demo.pdf
+++ b/assets/mock/verilex-demo.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 72 720 Td (VeriLex Demo PDF) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000114 00000 n 
+0000000236 00000 n 
+0000000328 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+380
+%%EOF

--- a/document-management.html
+++ b/document-management.html
@@ -77,6 +77,41 @@
     </main>
 
     <div
+      id="document-viewer"
+      class="document-viewer"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="document-viewer-title"
+      hidden
+    >
+      <div class="document-viewer__backdrop" data-viewer-action="close" aria-hidden="true"></div>
+      <div class="document-viewer__dialog" role="document">
+        <header class="document-viewer__header">
+          <h2 id="document-viewer-title">Dokument anzeigen</h2>
+          <button
+            type="button"
+            class="document-viewer__close"
+            aria-label="Dokument-Viewer schließen"
+            data-viewer-action="close"
+          >
+            ×
+          </button>
+        </header>
+        <p id="document-viewer-meta" class="document-viewer__meta" aria-live="polite"></p>
+        <div class="document-viewer__body">
+          <iframe
+            id="document-viewer-frame"
+            class="document-viewer__frame"
+            title="PDF-Vorschau"
+            loading="lazy"
+            hidden
+          ></iframe>
+          <div id="document-viewer-fallback" class="document-viewer__fallback" hidden></div>
+        </div>
+      </div>
+    </div>
+
+    <div
       id="global-error-overlay"
       class="error-overlay"
       role="alertdialog"
@@ -111,7 +146,7 @@
 
     <script type="application/json" id="document-seed-data">
       [
-        {
+        { 
           "id": "doc-001",
           "name": "Klageentwurf.pdf",
           "mimeType": "application/pdf",
@@ -120,7 +155,8 @@
           "uploadedBy": "RAin Dr. Hannah Keller",
           "status": "Entwurf – finale Prüfung läuft",
           "tags": ["Klage", "Entwurf"],
-          "notes": "Vor Versand an Mandantin prüfen."
+          "notes": "Vor Versand an Mandantin prüfen.",
+          "viewerUrl": "assets/mock/verilex-demo.pdf"
         },
         {
           "id": "doc-002",


### PR DESCRIPTION
## Summary
- add an accessible modal PDF viewer to the document management page with fallback handling
- enhance document action styles and wire the viewer into the client-side document list
- seed a demo PDF asset and update the ToDo list entry for the document viewer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a0e6ca690832081cd62ade81693f2