### PR TITLE
Add template assistant for reusable text blocks

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -37,8 +37,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 7. **Dokument-Viewer** – Baue ein modales Fenster zum Anzeigen von PDF-Dokumenten (z. B. über eingebettetes `<iframe>`).
    Status: ✅ erledigt – 2025-11-04
 
-8. **Vorlagen-Assistent** – Füge ein einfaches Formular hinzu, mit dem Textbausteine oder Vorlagen angezeigt, angepasst und in das Dokument eingefügt werden können.  
-   Status: ⬜
+8. **Vorlagen-Assistent** – Füge ein einfaches Formular hinzu, mit dem Textbausteine oder Vorlagen angezeigt, angepasst und in das Dokument eingefügt werden können.
+   Status: ✅ erledigt – 2025-11-04
 
 9. **Zeiterfassung mit Stoppuhr** – Ergänze eine Stoppuhr-Komponente, die die Zeit für eine Tätigkeit misst und als Eintrag in der Leistungsübersicht speichert.  
    Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -638,12 +638,419 @@ body {
   justify-content: flex-end;
 }
 
+.template-assistant-main {
+  width: min(1200px, 100%);
+  align-items: stretch;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.template-assistant {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.template-assistant__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.template-assistant__description {
+  margin: 0.5rem 0 0;
+  max-width: 52ch;
+  color: #4b5563;
+}
+
+.template-search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: min(320px, 100%);
+}
+
+.template-search input {
+  border-radius: 12px;
+  border: 1px solid rgba(47, 116, 192, 0.35);
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.template-search input:focus-visible {
+  outline: 3px solid rgba(47, 116, 192, 0.35);
+  outline-offset: 2px;
+  border-color: #2f74c0;
+  box-shadow: 0 0 0 4px rgba(47, 116, 192, 0.15);
+}
+
+.template-search__hint {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.template-assistant__layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+.template-list-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.template-list-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.template-list-section__summary {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.template-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.template-empty-state {
+  margin: 0;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.template-list__item {
+  margin: 0;
+}
+
+.template-card {
+  width: 100%;
+  text-align: left;
+  border-radius: 14px;
+  border: 1px solid rgba(31, 60, 136, 0.12);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(47, 116, 192, 0.04));
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.template-card:hover,
+.template-card:focus-visible {
+  border-color: rgba(47, 116, 192, 0.45);
+  box-shadow: 0 10px 24px rgba(31, 60, 136, 0.12);
+  transform: translateY(-2px);
+}
+
+.template-card--active {
+  border-color: #2f74c0;
+  box-shadow: 0 12px 30px rgba(47, 116, 192, 0.25);
+  background: linear-gradient(180deg, rgba(47, 116, 192, 0.12), rgba(47, 116, 192, 0.03));
+}
+
+.template-card__title {
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.template-card__summary {
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.template-card__meta {
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.template-editor-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.template-editor__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.template-details {
+  border: 1px solid rgba(47, 116, 192, 0.1);
+  border-radius: 14px;
+  background: rgba(47, 116, 192, 0.05);
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.template-details__name {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #1f3c88;
+}
+
+.template-details__summary {
+  margin: 0;
+  color: #4b5563;
+}
+
+.template-details__meta {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.template-details__meta div {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.template-details__meta dt {
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.template-details__meta dd {
+  margin: 0;
+  color: #1f2933;
+}
+
+.template-placeholder-hint {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.template-form {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.template-form__fields {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.template-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.template-form__label {
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.template-form__input {
+  border-radius: 12px;
+  border: 1px solid rgba(31, 60, 136, 0.2);
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  min-height: 48px;
+}
+
+.template-form__input:focus-visible {
+  outline: 3px solid rgba(47, 116, 192, 0.35);
+  outline-offset: 2px;
+  border-color: #2f74c0;
+  box-shadow: 0 0 0 4px rgba(47, 116, 192, 0.12);
+}
+
+.template-form__input--multiline {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.template-form__hint {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.template-preview {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.template-preview__label {
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.template-preview__output {
+  border-radius: 14px;
+  border: 1px solid rgba(31, 60, 136, 0.2);
+  padding: 1rem;
+  min-height: 200px;
+  font-family: inherit;
+  font-size: 1rem;
+  background: #fbfdff;
+  resize: vertical;
+}
+
+.template-preview__meta {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.template-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.template-feedback {
+  margin: 0;
+  color: #1f3c88;
+  font-weight: 600;
+  min-height: 1.2rem;
+}
+
+.document-draft {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.document-draft__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.document-draft__description {
+  margin: 0.35rem 0 0;
+  color: #4b5563;
+}
+
+.document-draft__textarea {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid rgba(31, 60, 136, 0.2);
+  padding: 1.1rem 1.2rem;
+  font-size: 1rem;
+  min-height: 240px;
+  resize: vertical;
+  font-family: inherit;
+  background: #fbfdff;
+}
+
+.document-draft__textarea:focus-visible {
+  outline: 3px solid rgba(47, 116, 192, 0.35);
+  outline-offset: 3px;
+  border-color: #2f74c0;
+}
+
+.template-history {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.template-history__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.template-history__summary {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.template-history__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.template-history__item {
+  border: 1px solid rgba(31, 60, 136, 0.14);
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  background: rgba(47, 116, 192, 0.06);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.template-history__item-title {
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.template-history__item-meta {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.template-history__item-excerpt {
+  margin: 0;
+  color: #1f2933;
+  white-space: pre-wrap;
+}
+
+.template-history__empty {
+  margin: 0;
+  color: #6b7280;
+  font-style: italic;
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;
   }
   to {
     opacity: 1;
+  }
+}
+
+@media (max-width: 1024px) {
+  .template-assistant__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .template-assistant__header {
+    align-items: stretch;
+  }
+
+  .template-search {
+    width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .template-form__actions {
+    flex-direction: column;
+  }
+
+  .document-draft__header {
+    align-items: stretch;
   }
 }
 

--- a/assets/js/template-assistant.js
+++ b/assets/js/template-assistant.js
@@ -1,0 +1,600 @@
+import { overlayInstance } from './app.js';
+
+function parseTemplateData() {
+  const dataEl = document.getElementById('template-data');
+  if (!dataEl) {
+    return [];
+  }
+
+  try {
+    const raw = dataEl.textContent ?? '[]';
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      throw new Error('Vorlagen-Daten müssen als Array vorliegen.');
+    }
+
+    return parsed.map((entry) => {
+      const providedId = String(entry.id ?? '').trim();
+      let generatedId = '';
+      if (!providedId) {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+          generatedId = crypto.randomUUID();
+        } else {
+          generatedId = `tpl-${Date.now()}-${Math.random().toString(16).slice(2, 6)}`;
+        }
+      }
+
+      return {
+        id: providedId || generatedId,
+        name: String(entry.name ?? 'Ohne Titel').trim(),
+        category: String(entry.category ?? 'Allgemein').trim(),
+        summary: String(entry.summary ?? '').trim(),
+        tags: Array.isArray(entry.tags)
+          ? entry.tags.map((tag) => String(tag ?? '').trim()).filter(Boolean)
+          : [],
+        placeholders: Array.isArray(entry.placeholders)
+          ? entry.placeholders.map((placeholder, index) => ({
+            id:
+              String(placeholder.id ?? '').trim() ||
+              `placeholder-${index + 1}-${Math.random().toString(16).slice(2, 6)}`,
+            label: String(placeholder.label ?? 'Platzhalter').trim(),
+            type: (placeholder.type ?? 'text').toString().toLowerCase(),
+            defaultValue: String(placeholder.defaultValue ?? ''),
+            hint: placeholder.hint ? String(placeholder.hint) : '',
+          }))
+        : [],
+        body: String(entry.body ?? ''),
+      };
+    });
+  } catch (error) {
+    console.error('Vorlagen-Daten konnten nicht geladen werden.', error);
+    overlayInstance?.show?.({
+      title: 'Vorlagen nicht verfügbar',
+      message: 'Die Demo-Vorlagen konnten nicht geladen werden.',
+      details: error,
+    });
+    return [];
+  }
+}
+
+const templates = parseTemplateData();
+const state = {
+  templates,
+  filteredTemplates: templates.slice(),
+  activeTemplateId: null,
+  userInputs: new Map(),
+  feedbackTimeout: null,
+  historyEntries: [],
+};
+
+const templateListEl = document.getElementById('template-list');
+const templateEmptyStateEl = document.getElementById('template-empty-state');
+const templateListSummaryEl = document.getElementById('template-list-summary');
+const searchInput = document.getElementById('template-search-input');
+
+const templateDetailsEl = document.getElementById('template-details');
+const templateNameEl = document.getElementById('template-name');
+const templateSummaryEl = document.getElementById('template-summary');
+const templateCategoryEl = document.getElementById('template-category');
+const templateTagsEl = document.getElementById('template-tags');
+const placeholderHintEl = document.getElementById('template-placeholder-hint');
+
+const templateForm = document.getElementById('template-form');
+const templateFieldsContainer = document.getElementById('template-fields');
+const previewOutput = document.getElementById('template-preview-output');
+const previewMeta = document.getElementById('template-preview-meta');
+const insertButton = document.getElementById('template-insert');
+const copyButton = document.getElementById('template-copy');
+const feedbackEl = document.getElementById('template-feedback');
+
+const draftTextarea = document.getElementById('document-draft-input');
+const draftClearButton = document.getElementById('document-draft-clear');
+
+const historyListEl = document.getElementById('template-history-list');
+const historyEmptyStateEl = document.getElementById('template-history-empty');
+const historySummaryEl = document.getElementById('template-history-summary');
+
+function formatTags(tags) {
+  if (!tags || tags.length === 0) {
+    return '–';
+  }
+
+  return tags.map((tag) => `#${tag}`).join(' · ');
+}
+
+function getWordCount(text) {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return 0;
+  }
+  const matches = trimmed.match(/\S+/g);
+  return matches ? matches.length : 0;
+}
+
+function buildTemplateText(template, values) {
+  if (!template) {
+    return '';
+  }
+
+  const replacements = values ?? {};
+  return template.body.replace(/\{\{\s*([\w-]+)\s*\}\}/g, (match, key) => {
+    const replacement = replacements[key];
+    if (replacement === undefined || replacement === null) {
+      return '';
+    }
+    return String(replacement);
+  });
+}
+
+function updatePreview(template) {
+  if (!previewOutput || !previewMeta) {
+    return;
+  }
+
+  const values = state.userInputs.get(template?.id ?? '') ?? {};
+  const previewText = buildTemplateText(template, values);
+  previewOutput.value = previewText;
+
+  const charCount = previewText.length;
+  const wordCount = getWordCount(previewText);
+  previewMeta.textContent = `${charCount} Zeichen · ${wordCount} Wörter`;
+}
+
+function clearFeedback() {
+  if (state.feedbackTimeout) {
+    clearTimeout(state.feedbackTimeout);
+    state.feedbackTimeout = null;
+  }
+  if (feedbackEl) {
+    feedbackEl.textContent = '';
+  }
+}
+
+function showFeedback(message) {
+  if (!feedbackEl) {
+    return;
+  }
+  clearFeedback();
+  feedbackEl.textContent = message;
+  state.feedbackTimeout = setTimeout(() => {
+    feedbackEl.textContent = '';
+    state.feedbackTimeout = null;
+  }, 6000);
+}
+
+function renderTemplateDetails(template) {
+  if (!template || !templateDetailsEl) {
+    templateDetailsEl?.setAttribute('hidden', '');
+    return;
+  }
+
+  templateDetailsEl.removeAttribute('hidden');
+  if (templateNameEl) {
+    templateNameEl.textContent = template.name;
+  }
+  if (templateSummaryEl) {
+    templateSummaryEl.textContent = template.summary || 'Keine Beschreibung vorhanden.';
+  }
+  if (templateCategoryEl) {
+    templateCategoryEl.textContent = template.category || 'Allgemein';
+  }
+  if (templateTagsEl) {
+    templateTagsEl.textContent = formatTags(template.tags);
+  }
+}
+
+function renderPlaceholderFields(template) {
+  if (!templateFieldsContainer) {
+    return;
+  }
+
+  templateFieldsContainer.innerHTML = '';
+
+  if (!template || template.placeholders.length === 0) {
+    return;
+  }
+
+  const currentValues = state.userInputs.get(template.id) ?? {};
+
+  template.placeholders.forEach((placeholder) => {
+    const fieldWrapper = document.createElement('div');
+    fieldWrapper.className = 'template-form__field';
+
+    const label = document.createElement('label');
+    const fieldId = `template-field-${template.id}-${placeholder.id}`;
+    label.setAttribute('for', fieldId);
+    label.className = 'template-form__label';
+    label.textContent = placeholder.label;
+
+    let input;
+    if (placeholder.type === 'textarea') {
+      input = document.createElement('textarea');
+      input.rows = 3;
+      input.className = 'template-form__input template-form__input--multiline';
+    } else {
+      input = document.createElement('input');
+      input.type = placeholder.type === 'date' ? 'text' : placeholder.type;
+      input.className = 'template-form__input';
+    }
+
+    input.id = fieldId;
+    input.dataset.placeholderId = placeholder.id;
+    input.value = currentValues[placeholder.id] ?? placeholder.defaultValue ?? '';
+
+    input.addEventListener('input', (event) => {
+      const target = event.target;
+      const placeholderId = target.dataset.placeholderId;
+      if (!placeholderId) {
+        return;
+      }
+      const newValue = target.value;
+      const templateValues = state.userInputs.get(template.id) ?? {};
+      templateValues[placeholderId] = newValue;
+      state.userInputs.set(template.id, templateValues);
+      updatePreview(template);
+      clearFeedback();
+    });
+
+    fieldWrapper.appendChild(label);
+
+    if (placeholder.hint) {
+      const hint = document.createElement('p');
+      hint.className = 'template-form__hint';
+      hint.textContent = placeholder.hint;
+      hint.id = `${fieldId}-hint`;
+      fieldWrapper.appendChild(hint);
+      input.setAttribute('aria-describedby', hint.id);
+    }
+
+    fieldWrapper.appendChild(input);
+    templateFieldsContainer.appendChild(fieldWrapper);
+  });
+}
+
+function updateListSummary() {
+  if (!templateListSummaryEl) {
+    return;
+  }
+  const total = state.templates.length;
+  const current = state.filteredTemplates.length;
+  const query = searchInput?.value?.trim();
+
+  if (total === 0) {
+    templateListSummaryEl.textContent = 'Keine Vorlagen verfügbar.';
+    return;
+  }
+
+  if (!query) {
+    templateListSummaryEl.textContent = `${current} Vorlagen verfügbar.`;
+    return;
+  }
+
+  templateListSummaryEl.textContent = `${current} von ${total} Vorlagen entsprechen Ihrer Suche.`;
+}
+
+function renderTemplateList() {
+  if (!templateListEl) {
+    return;
+  }
+
+  templateListEl.innerHTML = '';
+
+  if (state.filteredTemplates.length === 0) {
+    templateEmptyStateEl?.removeAttribute('hidden');
+    updateListSummary();
+    return;
+  }
+
+  templateEmptyStateEl?.setAttribute('hidden', '');
+
+  state.filteredTemplates.forEach((template) => {
+    const listItem = document.createElement('li');
+    listItem.className = 'template-list__item';
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'template-card';
+    button.dataset.templateId = template.id;
+    button.setAttribute('aria-pressed', template.id === state.activeTemplateId ? 'true' : 'false');
+
+    if (template.id === state.activeTemplateId) {
+      button.classList.add('template-card--active');
+    }
+
+    const title = document.createElement('span');
+    title.className = 'template-card__title';
+    title.textContent = template.name;
+
+    const description = document.createElement('span');
+    description.className = 'template-card__summary';
+    description.textContent = template.summary || 'Keine Beschreibung hinterlegt.';
+
+    const meta = document.createElement('span');
+    meta.className = 'template-card__meta';
+    const tagText = template.tags.length > 0 ? template.tags.map((tag) => `#${tag}`).join(' · ') : 'Keine Tags';
+    meta.textContent = `${template.category} · ${tagText}`;
+
+    button.appendChild(title);
+    button.appendChild(description);
+    button.appendChild(meta);
+
+    listItem.appendChild(button);
+    templateListEl.appendChild(listItem);
+  });
+
+  updateListSummary();
+}
+
+function selectTemplate(templateId) {
+  if (!templateId) {
+    return;
+  }
+
+  if (templateId === state.activeTemplateId) {
+    return;
+  }
+
+  const template = state.templates.find((item) => item.id === templateId);
+  if (!template) {
+    return;
+  }
+
+  state.activeTemplateId = templateId;
+  if (!state.userInputs.has(templateId)) {
+    const defaults = {};
+    template.placeholders.forEach((placeholder) => {
+      defaults[placeholder.id] = placeholder.defaultValue ?? '';
+    });
+    state.userInputs.set(templateId, defaults);
+  }
+
+  placeholderHintEl?.setAttribute('hidden', '');
+  templateForm?.removeAttribute('hidden');
+  renderTemplateDetails(template);
+  renderPlaceholderFields(template);
+  updatePreview(template);
+  if (insertButton) {
+    insertButton.disabled = false;
+  }
+  if (copyButton) {
+    copyButton.disabled = false;
+  }
+  renderTemplateList();
+  clearFeedback();
+}
+
+function resetSelection() {
+  state.activeTemplateId = null;
+  templateDetailsEl?.setAttribute('hidden', '');
+  templateForm?.setAttribute('hidden', '');
+  placeholderHintEl?.removeAttribute('hidden');
+  if (templateFieldsContainer) {
+    templateFieldsContainer.innerHTML = '';
+  }
+  if (previewOutput) {
+    previewOutput.value = '';
+  }
+  if (previewMeta) {
+    previewMeta.textContent = '';
+  }
+  if (insertButton) {
+    insertButton.disabled = true;
+  }
+  if (copyButton) {
+    copyButton.disabled = true;
+  }
+  renderTemplateList();
+}
+
+function matchesQuery(template, query) {
+  if (!query) {
+    return true;
+  }
+  const haystack = [
+    template.name,
+    template.category,
+    template.summary,
+    ...(template.tags ?? []),
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  return haystack.includes(query);
+}
+
+function handleSearchInput(event) {
+  const value = event.target.value.toLowerCase();
+  state.filteredTemplates = state.templates.filter((template) => matchesQuery(template, value));
+
+  if (state.filteredTemplates.length === 0) {
+    resetSelection();
+    return;
+  }
+
+  if (!state.filteredTemplates.some((template) => template.id === state.activeTemplateId)) {
+    selectTemplate(state.filteredTemplates[0].id);
+  } else {
+    renderTemplateList();
+  }
+}
+
+function ensureSelectionOnLoad() {
+  if (state.templates.length === 0) {
+    resetSelection();
+    return;
+  }
+
+  const firstTemplate = state.templates[0];
+  selectTemplate(firstTemplate.id);
+}
+
+function appendToDraft(template, previewText) {
+  if (!draftTextarea) {
+    return;
+  }
+
+  const currentValue = draftTextarea.value;
+  const hasContent = currentValue.trim().length > 0;
+  const sanitizedCurrent = hasContent ? currentValue.replace(/\s+$/, '') : '';
+  const blockSeparator = hasContent ? '\n\n' : '';
+  draftTextarea.value = `${sanitizedCurrent}${blockSeparator}${previewText}`;
+  draftTextarea.focus();
+  draftTextarea.setSelectionRange(draftTextarea.value.length, draftTextarea.value.length);
+}
+
+function formatHistoryEntry(template, previewText) {
+  const timestamp = new Date();
+  const formatter = new Intl.DateTimeFormat('de-DE', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  });
+
+  return {
+    id: `${template.id}-${timestamp.getTime()}`,
+    templateName: template.name,
+    insertedAt: formatter.format(timestamp),
+    excerpt: previewText.length > 160 ? `${previewText.slice(0, 157)}…` : previewText,
+  };
+}
+
+function renderHistory() {
+  if (!historyListEl || !historySummaryEl) {
+    return;
+  }
+
+  historyListEl.innerHTML = '';
+
+  if (state.historyEntries.length === 0) {
+    historyEmptyStateEl?.removeAttribute('hidden');
+    historySummaryEl.textContent = 'Noch keine Einträge vorhanden.';
+    return;
+  }
+
+  historyEmptyStateEl?.setAttribute('hidden', '');
+
+  state.historyEntries.forEach((entry) => {
+    const listItem = document.createElement('li');
+    listItem.className = 'template-history__item';
+
+    const title = document.createElement('div');
+    title.className = 'template-history__item-title';
+    title.textContent = entry.templateName;
+
+    const meta = document.createElement('div');
+    meta.className = 'template-history__item-meta';
+    meta.textContent = `Eingefügt am ${entry.insertedAt}`;
+
+    const excerpt = document.createElement('p');
+    excerpt.className = 'template-history__item-excerpt';
+    excerpt.textContent = entry.excerpt || 'Kein Text verfügbar.';
+
+    listItem.appendChild(title);
+    listItem.appendChild(meta);
+    listItem.appendChild(excerpt);
+    historyListEl.appendChild(listItem);
+  });
+
+  const count = state.historyEntries.length;
+  historySummaryEl.textContent = `${count} ${count === 1 ? 'Eintrag' : 'Einträge'} übernommen.`;
+}
+
+function handleInsertClick() {
+  const template = state.templates.find((item) => item.id === state.activeTemplateId);
+  if (!template) {
+    showFeedback('Bitte wählen Sie zuerst eine Vorlage aus.');
+    return;
+  }
+
+  const previewText = previewOutput?.value ?? '';
+  if (!previewText.trim()) {
+    showFeedback('Die aktuelle Vorlage enthält keinen Text zum Einfügen.');
+    return;
+  }
+
+  appendToDraft(template, previewText);
+  state.historyEntries.unshift(formatHistoryEntry(template, previewText));
+  if (state.historyEntries.length > 10) {
+    state.historyEntries = state.historyEntries.slice(0, 10);
+  }
+  renderHistory();
+  showFeedback(`Vorlage „${template.name}“ wurde in den Entwurf eingefügt.`);
+}
+
+async function handleCopyClick() {
+  const template = state.templates.find((item) => item.id === state.activeTemplateId);
+  if (!template) {
+    showFeedback('Bitte wählen Sie zuerst eine Vorlage aus.');
+    return;
+  }
+
+  const previewText = previewOutput?.value ?? '';
+  if (!previewText.trim()) {
+    showFeedback('Die aktuelle Vorlage enthält keinen Text zum Kopieren.');
+    return;
+  }
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(previewText);
+    } else {
+      previewOutput?.focus();
+      previewOutput?.select();
+      const successful = document.execCommand('copy');
+      previewOutput?.setSelectionRange(previewOutput.value.length, previewOutput.value.length);
+      if (!successful) {
+        throw new Error('Kopieren nicht unterstützt.');
+      }
+    }
+    showFeedback('Textbaustein wurde in die Zwischenablage kopiert.');
+  } catch (error) {
+    console.warn('Konnte Text nicht in Zwischenablage kopieren.', error);
+    overlayInstance?.show?.({
+      title: 'Zwischenablage nicht verfügbar',
+      message: 'Der Text konnte nicht automatisch kopiert werden.',
+      details: error,
+    });
+  }
+}
+
+function handleDraftClear() {
+  if (!draftTextarea) {
+    return;
+  }
+  draftTextarea.value = '';
+  draftTextarea.focus();
+  showFeedback('Der Dokumententwurf wurde geleert.');
+}
+
+function handleListClick(event) {
+  const button = event.target.closest('button[data-template-id]');
+  if (!button) {
+    return;
+  }
+  const { templateId } = button.dataset;
+  selectTemplate(templateId);
+}
+
+function init() {
+  if (!templateListEl) {
+    return;
+  }
+
+  renderTemplateList();
+  ensureSelectionOnLoad();
+
+  templateListEl.addEventListener('click', handleListClick);
+  searchInput?.addEventListener('input', handleSearchInput);
+  insertButton?.addEventListener('click', handleInsertClick);
+  copyButton?.addEventListener('click', handleCopyClick);
+  draftClearButton?.addEventListener('click', handleDraftClear);
+
+  if (insertButton) {
+    insertButton.disabled = true;
+  }
+  if (copyButton) {
+    copyButton.disabled = true;
+  }
+  renderHistory();
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
           </button>
           <a class="btn btn-primary" href="mandate-wizard.html">Mandats-Wizard starten</a>
           <a class="btn btn-secondary" href="document-management.html">Dokumentenverwaltung</a>
+          <a class="btn btn-secondary" href="template-assistant.html">Vorlagen-Assistent</a>
         </div>
       </section>
 

--- a/template-assistant.html
+++ b/template-assistant.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Vorlagen-Assistent</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>VeriLex Demo</h1>
+      <p class="app-subtitle">Vorlagen-Assistent für Textbausteine</p>
+    </header>
+
+    <main class="app-main template-assistant-main" aria-live="polite">
+      <nav class="case-breadcrumb" aria-label="Brotkrumen">
+        <a class="case-breadcrumb__link" href="index.html">&larr; Zur Startseite</a>
+      </nav>
+
+      <section class="app-card template-assistant" aria-labelledby="template-assistant-title">
+        <header class="template-assistant__header">
+          <div>
+            <h2 id="template-assistant-title">Textbausteine auswählen &amp; anpassen</h2>
+            <p class="template-assistant__description">
+              Wählen Sie links eine Vorlage, passen Sie Platzhaltertexte an und fügen Sie den finalen Text direkt in Ihren Dokumententwurf ein.
+            </p>
+          </div>
+          <form class="template-search" role="search" aria-label="Vorlagen durchsuchen">
+            <label class="visually-hidden" for="template-search-input">Vorlagen durchsuchen</label>
+            <input
+              id="template-search-input"
+              type="search"
+              name="query"
+              placeholder="Nach Titel, Kategorie oder Tags suchen"
+              autocomplete="off"
+              spellcheck="false"
+              aria-describedby="template-search-hint"
+            />
+            <p id="template-search-hint" class="template-search__hint">Eingabe sofort, keine Enter-Taste nötig.</p>
+          </form>
+        </header>
+
+        <div class="template-assistant__layout">
+          <section class="template-list-section" aria-labelledby="template-list-title">
+            <div class="template-list-section__header">
+              <h3 id="template-list-title">Verfügbare Vorlagen</h3>
+              <p class="template-list-section__summary" id="template-list-summary" role="status" aria-live="polite"></p>
+            </div>
+            <ul id="template-list" class="template-list" role="list"></ul>
+            <p id="template-empty-state" class="template-empty-state" hidden>
+              Keine Vorlage erfüllt aktuell die Suchkriterien. Bitte passen Sie den Suchbegriff an.
+            </p>
+          </section>
+
+          <section class="template-editor-section" aria-labelledby="template-editor-title">
+            <header class="template-editor__header">
+              <h3 id="template-editor-title">Vorlage bearbeiten</h3>
+              <p id="template-editor-description">
+                Wählen Sie eine Vorlage aus der Liste, um Platzhalter auszufüllen. Die Vorschau aktualisiert sich automatisch.
+              </p>
+            </header>
+            <article id="template-details" class="template-details" hidden>
+              <h4 id="template-name" class="template-details__name"></h4>
+              <p id="template-summary" class="template-details__summary"></p>
+              <dl class="template-details__meta">
+                <div>
+                  <dt>Kategorie</dt>
+                  <dd id="template-category"></dd>
+                </div>
+                <div>
+                  <dt>Tags</dt>
+                  <dd id="template-tags"></dd>
+                </div>
+              </dl>
+            </article>
+            <p id="template-placeholder-hint" class="template-placeholder-hint">
+              Tipp: Nutzen Sie die Suche, um schnell passende Textbausteine für wiederkehrende Aufgaben zu finden.
+            </p>
+            <form id="template-form" class="template-form" novalidate hidden>
+              <div id="template-fields" class="template-form__fields"></div>
+              <div class="template-preview">
+                <label for="template-preview-output" class="template-preview__label">Vorschau des Textbausteins</label>
+                <textarea
+                  id="template-preview-output"
+                  class="template-preview__output"
+                  rows="10"
+                  readonly
+                  aria-describedby="template-preview-meta"
+                ></textarea>
+                <p id="template-preview-meta" class="template-preview__meta"></p>
+              </div>
+              <div class="template-form__actions">
+                <button type="button" id="template-insert" class="btn btn-primary">In Dokument einfügen</button>
+                <button type="button" id="template-copy" class="btn btn-secondary">In Zwischenablage kopieren</button>
+              </div>
+              <p id="template-feedback" class="template-feedback" role="status" aria-live="polite"></p>
+            </form>
+          </section>
+        </div>
+      </section>
+
+      <section class="app-card document-draft" aria-labelledby="document-draft-title">
+        <header class="document-draft__header">
+          <div>
+            <h2 id="document-draft-title">Dokumententwurf</h2>
+            <p class="document-draft__description">
+              Hier können Sie die eingefügten Textbausteine weiterbearbeiten oder kombinieren.
+            </p>
+          </div>
+          <button type="button" id="document-draft-clear" class="btn btn-secondary">Entwurf leeren</button>
+        </header>
+        <label class="visually-hidden" for="document-draft-input">Dokumententwurf bearbeiten</label>
+        <textarea
+          id="document-draft-input"
+          class="document-draft__textarea"
+          rows="12"
+          placeholder="Hier entsteht Ihr Dokument. Nutzen Sie den Vorlagen-Assistenten, um Textbausteine einzufügen."
+        ></textarea>
+        <section class="template-history" aria-labelledby="template-history-title">
+          <div class="template-history__header">
+            <h3 id="template-history-title">Einfügeprotokoll</h3>
+            <p id="template-history-summary" class="template-history__summary"></p>
+          </div>
+          <ul id="template-history-list" class="template-history__list" role="list"></ul>
+          <p id="template-history-empty" class="template-history__empty" hidden>
+            Noch keine Textbausteine eingefügt. Sobald Sie eine Vorlage übernehmen, erscheint sie hier.
+          </p>
+        </section>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details" hidden>
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">Seite neu laden</button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">Schließen</button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="application/json" id="template-data">
+      [
+        {
+          "id": "tpl-demand-letter",
+          "name": "Zahlungsaufforderung mit Frist",
+          "category": "Forderungsmanagement",
+          "summary": "Formales Anschreiben an die Gegenseite mit klarer Zahlungsfrist und Ansprechpartner.",
+          "tags": ["Mahnung", "Fristsetzung", "Zivilrecht"],
+          "placeholders": [
+            {
+              "id": "recipient",
+              "label": "Adressat:in (inkl. Anrede)",
+              "type": "text",
+              "defaultValue": "Sehr geehrte Frau Schulz"
+            },
+            {
+              "id": "reference",
+              "label": "Aktenzeichen/Referenz",
+              "type": "text",
+              "defaultValue": "V-2024-017"
+            },
+            {
+              "id": "claimAmount",
+              "label": "Forderungsbetrag",
+              "type": "text",
+              "defaultValue": "3.450,00 €"
+            },
+            {
+              "id": "dueDate",
+              "label": "Zahlungsfrist",
+              "type": "text",
+              "defaultValue": "15.11.2025"
+            },
+            {
+              "id": "contact",
+              "label": "Kontakt für Rückfragen",
+              "type": "text",
+              "defaultValue": "RAin Dr. Hannah Keller, Tel. 089 1234 56-0"
+            }
+          ],
+          "body": "{{recipient}},\n\nunter Bezugnahme auf unsere Angelegenheit {{reference}} fordern wir Sie letztmalig auf, den ausstehenden Betrag in Höhe von {{claimAmount}} bis spätestens {{dueDate}} auf das bekannte Kanzleikonto zu überweisen.\n\nSollten Sie Rückfragen haben, wenden Sie sich bitte an {{contact}}.\n\nMit freundlichen Grüßen\nVeriLex Kanzlei-Team"
+        },
+        {
+          "id": "tpl-status-update",
+          "name": "Statusbericht an Mandant:in",
+          "category": "Mandantenkommunikation",
+          "summary": "Kurzer Statusbericht zu offenen Aufgaben und nächsten Schritten.",
+          "tags": ["Update", "Mandant", "Transparenz"],
+          "placeholders": [
+            {
+              "id": "clientName",
+              "label": "Mandant:in",
+              "type": "text",
+              "defaultValue": "Müller GmbH"
+            },
+            {
+              "id": "caseTopic",
+              "label": "Anliegen/Projekt",
+              "type": "text",
+              "defaultValue": "Vertragsprüfung Lieferantenrahmenvertrag"
+            },
+            {
+              "id": "currentStatus",
+              "label": "Aktueller Status",
+              "type": "textarea",
+              "defaultValue": "Der Vertragsentwurf wurde überarbeitet und enthält nun die gewünschten Klauseln zur Haftungsbegrenzung."
+            },
+            {
+              "id": "nextSteps",
+              "label": "Nächste Schritte",
+              "type": "textarea",
+              "defaultValue": "Besprechung mit dem Einkaufsteam am 07.11. vorbereiten und Feedback in Fassung 4 einarbeiten."
+            },
+            {
+              "id": "contactPerson",
+              "label": "Kontaktperson",
+              "type": "text",
+              "defaultValue": "RA Felix Sommer"
+            }
+          ],
+          "body": "Sehr geehrte Damen und Herren der {{clientName}},\n\nkurz zum Stand unserer Angelegenheit \"{{caseTopic}}\":\n\nAktueller Status:\n{{currentStatus}}\n\nNächste Schritte:\n{{nextSteps}}\n\nFür Rückfragen steht Ihnen {{contactPerson}} jederzeit gerne zur Verfügung.\n\nMit freundlichen Grüßen\nIhr VeriLex Team"
+        },
+        {
+          "id": "tpl-meeting-minutes",
+          "name": "Kurzprotokoll Besprechung",
+          "category": "Dokumentation",
+          "summary": "Strukturiertes Kurzprotokoll für interne oder externe Abstimmungen.",
+          "tags": ["Protokoll", "Besprechung", "Team"],
+          "placeholders": [
+            {
+              "id": "meetingDate",
+              "label": "Datum der Besprechung",
+              "type": "text",
+              "defaultValue": "04.11.2025"
+            },
+            {
+              "id": "participants",
+              "label": "Teilnehmende",
+              "type": "textarea",
+              "defaultValue": "RAin Dr. Hannah Keller, RA Felix Sommer, Mandantin Frau Müller"
+            },
+            {
+              "id": "topics",
+              "label": "Besprochene Themen",
+              "type": "textarea",
+              "defaultValue": "1. Überarbeitung Wettbewerbsverbotsklausel\n2. Zeitplan für Vertragsfinalisierung\n3. Abstimmung Kommunikation Mandantin"
+            },
+            {
+              "id": "decisions",
+              "label": "Entscheidungen",
+              "type": "textarea",
+              "defaultValue": "- Wettbewerbsverbot wird auf 12 Monate begrenzt\n- Finale Fassung bis 12.11. fertigstellen"
+            },
+            {
+              "id": "actionItems",
+              "label": "To-dos",
+              "type": "textarea",
+              "defaultValue": "- Feedback der Mandantin bis 08.11. einarbeiten\n- Abstimmung mit Compliance-Team terminieren"
+            }
+          ],
+          "body": "Kurzprotokoll Besprechung vom {{meetingDate}}\n\nTeilnehmende:\n{{participants}}\n\nThemen:\n{{topics}}\n\nBeschlüsse:\n{{decisions}}\n\nTo-dos:\n{{actionItems}}\n\nBitte um kurze Rückmeldung, falls Ergänzungen erforderlich sind."
+        }
+      ]
+    </script>
+
+    <script src="assets/js/template-assistant.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated Vorlagen-Assistent page with searchable template list, live preview, and a document draft workspace
- implement template-assistant JavaScript to handle placeholder inputs, insertion history, clipboard copy, and error feedback
- extend shared styles, surface the new assistant in the welcome actions, and update the ToDo list status

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690a240ad65083209c866e2e1fcaa55d