### PR TITLE
Add time tracking stopwatch and overview page

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -40,8 +40,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 8. **Vorlagen-Assistent** – Füge ein einfaches Formular hinzu, mit dem Textbausteine oder Vorlagen angezeigt, angepasst und in das Dokument eingefügt werden können.
    Status: ✅ erledigt – 2025-11-04
 
-9. **Zeiterfassung mit Stoppuhr** – Ergänze eine Stoppuhr-Komponente, die die Zeit für eine Tätigkeit misst und als Eintrag in der Leistungsübersicht speichert.  
-   Status: ⬜
+9. **Zeiterfassung mit Stoppuhr** – Ergänze eine Stoppuhr-Komponente, die die Zeit für eine Tätigkeit misst und als Eintrag in der Leistungsübersicht speichert.
+   Status: ✅ erledigt – 2025-11-05
 
 10. **Leistungsübersicht** – Erstelle eine Tabelle aller Leistungen mit Filter- und Summenfunktion (z. B. Stunden nach Mandant).  
     Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1798,3 +1798,279 @@ body {
     font-size: 0.9rem;
   }
 }
+
+.time-tracking-layout {
+  width: min(1100px, 100%);
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  align-self: stretch;
+  margin: 0 auto;
+}
+
+.time-tracking-layout .app-card {
+  width: 100%;
+}
+
+.time-tracking-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.time-tracking-card__description {
+  margin: 0;
+  color: #4b5563;
+  max-width: 60ch;
+}
+
+.time-tracking-card__status {
+  min-height: 1.5rem;
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.time-tracking-card__status--success {
+  color: #047857;
+}
+
+.time-tracking-card__status--warning {
+  color: #b45309;
+}
+
+.time-tracking-card__status--error {
+  color: #b91c1c;
+}
+
+.time-tracking-form {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-field label {
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  border: 1px solid rgba(47, 116, 192, 0.25);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.form-field input:focus-visible,
+.form-field select:focus-visible,
+.form-field textarea:focus-visible {
+  outline: 3px solid rgba(47, 116, 192, 0.35);
+  outline-offset: 2px;
+  border-color: #2f74c0;
+  box-shadow: 0 0 0 4px rgba(47, 116, 192, 0.15);
+}
+
+.form-field textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.form-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.stopwatch {
+  margin-top: 2rem;
+  background: linear-gradient(180deg, rgba(47, 116, 192, 0.08), rgba(47, 116, 192, 0.02));
+  border: 1px solid rgba(47, 116, 192, 0.2);
+  border-radius: 18px;
+  padding: clamp(1.25rem, 4vw, 2rem);
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+}
+
+.stopwatch__display {
+  font-size: clamp(2.5rem, 6vw, 3.6rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #1f3c88;
+}
+
+.stopwatch__meta {
+  margin: 0;
+  color: #4b5563;
+}
+
+.stopwatch__controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.performance-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.performance-card__description {
+  margin: 0;
+  color: #4b5563;
+  max-width: 60ch;
+}
+
+.performance-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 0;
+}
+
+.performance-summary__item {
+  background: rgba(47, 116, 192, 0.08);
+  border-radius: 14px;
+  padding: 0.75rem 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+  min-width: 140px;
+}
+
+.performance-summary__item dt {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6b7280;
+}
+
+.performance-summary__item dd {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #1f3c88;
+}
+
+.table-wrapper {
+  margin-top: 1.25rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 16px;
+  overflow-x: auto;
+  background: rgba(255, 255, 255, 0.98);
+}
+
+.performance-table {
+  width: 100%;
+  min-width: 640px;
+  border-collapse: collapse;
+}
+
+.performance-table thead {
+  background: rgba(47, 116, 192, 0.08);
+}
+
+.performance-table th,
+.performance-table td {
+  text-align: left;
+  padding: 0.75rem 0.95rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  vertical-align: top;
+}
+
+.performance-table th {
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6b7280;
+}
+
+.performance-table__primary {
+  display: block;
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.performance-table__secondary {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.performance-table__actions {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.performance-table__action {
+  background: rgba(47, 116, 192, 0.08);
+  border: 1px solid rgba(47, 116, 192, 0.25);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #1f3c88;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.performance-table__action:hover,
+.performance-table__action:focus-visible {
+  background: rgba(47, 116, 192, 0.18);
+  color: #163470;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(47, 116, 192, 0.12);
+}
+
+.performance-empty-state {
+  margin: 1.25rem 0 0;
+  padding: 1.25rem;
+  text-align: center;
+  border-radius: 14px;
+  border: 1px dashed rgba(47, 116, 192, 0.25);
+  background: rgba(47, 116, 192, 0.04);
+  color: #4b5563;
+}
+
+@media (max-width: 720px) {
+  .time-tracking-form {
+    grid-template-columns: 1fr;
+  }
+
+  .stopwatch {
+    padding: 1.25rem;
+  }
+
+  .performance-summary {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .performance-summary__item {
+    width: 100%;
+  }
+
+  .performance-table {
+    min-width: 100%;
+  }
+
+  .performance-table__actions {
+    text-align: left;
+  }
+}

--- a/assets/js/time-tracking.js
+++ b/assets/js/time-tracking.js
@@ -1,0 +1,582 @@
+import { overlayInstance } from './app.js';
+
+const STORAGE_KEY = 'verilex:time-entries';
+
+const form = document.getElementById('time-tracking-form');
+const activityInput = document.getElementById('activity-title');
+const caseSelect = document.getElementById('activity-case');
+const notesInput = document.getElementById('activity-notes');
+const statusEl = document.getElementById('time-tracking-status');
+const displayEl = document.getElementById('stopwatch-display');
+const metaEl = document.getElementById('stopwatch-meta');
+const startButton = document.getElementById('stopwatch-start');
+const pauseButton = document.getElementById('stopwatch-pause');
+const resumeButton = document.getElementById('stopwatch-resume');
+const stopButton = document.getElementById('stopwatch-stop');
+const resetButton = document.getElementById('stopwatch-reset');
+const tableBody = document.getElementById('performance-table-body');
+const emptyState = document.getElementById('performance-empty-state');
+const entryCountEl = document.getElementById('performance-entry-count');
+const totalDurationEl = document.getElementById('performance-total-duration');
+
+if (!form || !activityInput || !caseSelect || !notesInput) {
+  console.warn('Time tracking form could not be initialized.');
+}
+
+let entries = [];
+
+let stopwatchState = 'idle';
+let animationFrameId = null;
+let startHighResTimestamp = 0;
+let accumulatedDurationMs = 0;
+let startedAt = null;
+
+function generateEntryId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `entry-${Math.random().toString(16).slice(2)}-${Date.now()}`;
+}
+
+function setStatus(message, variant = 'info') {
+  if (!statusEl) {
+    return;
+  }
+
+  statusEl.textContent = message ?? '';
+  statusEl.className = 'time-tracking-card__status';
+  if (message) {
+    statusEl.classList.add(`time-tracking-card__status--${variant}`);
+  }
+}
+
+function formatDuration(ms) {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600)
+    .toString()
+    .padStart(2, '0');
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = Math.floor(totalSeconds % 60)
+    .toString()
+    .padStart(2, '0');
+
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+function formatDurationSummary(ms) {
+  const totalMinutes = Math.max(0, Math.floor(ms / 60000));
+  const hours = Math.floor(totalMinutes / 60)
+    .toString()
+    .padStart(2, '0');
+  const minutes = Math.floor(totalMinutes % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${hours}:${minutes} h`;
+}
+
+function formatDateTime(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Unbekannt';
+  }
+
+  return new Intl.DateTimeFormat('de-DE', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+function formatCaseLabel(entry) {
+  if (!entry.caseNumber) {
+    return 'Keine Zuordnung';
+  }
+
+  if (entry.caseTitle) {
+    return `${entry.caseNumber} – ${entry.caseTitle}`;
+  }
+
+  return entry.caseNumber;
+}
+
+function stopAnimation() {
+  if (animationFrameId !== null) {
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+}
+
+function updateDisplay() {
+  if (!displayEl) {
+    return;
+  }
+
+  let elapsed = accumulatedDurationMs;
+  if (stopwatchState === 'running') {
+    elapsed += performance.now() - startHighResTimestamp;
+  }
+
+  displayEl.textContent = formatDuration(elapsed);
+  animationFrameId = requestAnimationFrame(updateDisplay);
+}
+
+function setButtonsState(state) {
+  if (!startButton || !pauseButton || !resumeButton || !stopButton || !resetButton) {
+    return;
+  }
+
+  if (state === 'idle') {
+    startButton.disabled = false;
+    pauseButton.disabled = true;
+    resumeButton.disabled = true;
+    resumeButton.hidden = true;
+    stopButton.disabled = true;
+    resetButton.disabled = true;
+  } else if (state === 'running') {
+    startButton.disabled = true;
+    pauseButton.disabled = false;
+    resumeButton.disabled = true;
+    resumeButton.hidden = true;
+    stopButton.disabled = false;
+    resetButton.disabled = false;
+  } else if (state === 'paused') {
+    startButton.disabled = true;
+    pauseButton.disabled = true;
+    resumeButton.disabled = false;
+    resumeButton.hidden = false;
+    resumeButton.disabled = false;
+    stopButton.disabled = false;
+    resetButton.disabled = false;
+  }
+}
+
+function resetStopwatch({ announce = false } = {}) {
+  stopAnimation();
+  stopwatchState = 'idle';
+  accumulatedDurationMs = 0;
+  startHighResTimestamp = 0;
+  startedAt = null;
+  if (displayEl) {
+    displayEl.textContent = '00:00:00';
+  }
+  if (metaEl) {
+    metaEl.textContent = 'Noch nicht gestartet.';
+  }
+  setButtonsState('idle');
+
+  if (announce) {
+    setStatus('Die Stoppuhr wurde zurückgesetzt.', 'info');
+  }
+}
+
+function persistEntries() {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch (error) {
+    console.error('Zeitbuchungen konnten nicht gespeichert werden.', error);
+    overlayInstance?.show?.({
+      title: 'Speichern nicht möglich',
+      message: 'Die Zeiterfassungsdaten konnten nicht im Browser gespeichert werden.',
+      details: error,
+    });
+  }
+}
+
+function loadEntries() {
+  if (typeof localStorage === 'undefined') {
+    entries = [];
+    return;
+  }
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      entries = [];
+      return;
+    }
+
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      entries = parsed
+        .filter((entry) => typeof entry === 'object' && entry !== null)
+        .map((entry) => {
+          const duration = Number(entry.durationMs);
+          return {
+            id: typeof entry.id === 'string' && entry.id ? entry.id : generateEntryId(),
+            activity: String(entry.activity ?? '').trim() || 'Ohne Titel',
+            caseNumber: String(entry.caseNumber ?? '').trim(),
+            caseTitle: String(entry.caseTitle ?? '').trim(),
+            notes: String(entry.notes ?? '').trim(),
+            startedAt: entry.startedAt ?? null,
+            endedAt: entry.endedAt ?? null,
+            durationMs: Number.isFinite(duration) ? duration : 0,
+            createdLabel: typeof entry.createdLabel === 'string' ? entry.createdLabel : '',
+          };
+        });
+    } else {
+      entries = [];
+    }
+  } catch (error) {
+    console.error('Gespeicherte Zeiterfassung konnte nicht geladen werden.', error);
+    entries = [];
+    overlayInstance?.show?.({
+      title: 'Daten konnten nicht geladen werden',
+      message: 'Die gespeicherten Zeitbucheinträge stehen derzeit nicht zur Verfügung.',
+      details: error,
+    });
+  }
+}
+
+function renderEntries() {
+  if (!tableBody || !emptyState || !entryCountEl || !totalDurationEl) {
+    return;
+  }
+
+  tableBody.innerHTML = '';
+  if (!Array.isArray(entries) || entries.length === 0) {
+    emptyState.hidden = false;
+    entryCountEl.textContent = '0';
+    totalDurationEl.textContent = '00:00 h';
+    return;
+  }
+
+  emptyState.hidden = true;
+  entryCountEl.textContent = String(entries.length);
+
+  let totalDuration = 0;
+
+  entries
+    .slice()
+    .sort((a, b) => {
+      const timeA = new Date(a.startedAt).getTime();
+      const timeB = new Date(b.startedAt).getTime();
+      const isValidA = Number.isFinite(timeA);
+      const isValidB = Number.isFinite(timeB);
+
+      if (isValidA && isValidB) {
+        return timeB - timeA;
+      }
+
+      if (isValidA) {
+        return -1;
+      }
+
+      if (isValidB) {
+        return 1;
+      }
+
+      return 0;
+    })
+    .forEach((entry) => {
+      const row = document.createElement('tr');
+
+      const activityCell = document.createElement('td');
+      const activityPrimary = document.createElement('span');
+      activityPrimary.className = 'performance-table__primary';
+      activityPrimary.textContent = entry.activity || 'Ohne Titel';
+      activityCell.appendChild(activityPrimary);
+
+      const createdLabelText = entry.createdLabel || (entry.endedAt ? `Erfasst am ${formatDateTime(entry.endedAt)}` : '');
+      if (createdLabelText) {
+        const activitySecondary = document.createElement('span');
+        activitySecondary.className = 'performance-table__secondary';
+        activitySecondary.textContent = createdLabelText;
+        activityCell.appendChild(activitySecondary);
+      }
+      row.appendChild(activityCell);
+
+      const caseCell = document.createElement('td');
+      caseCell.textContent = formatCaseLabel(entry);
+      row.appendChild(caseCell);
+
+      const startCell = document.createElement('td');
+      startCell.textContent = formatDateTime(entry.startedAt);
+      row.appendChild(startCell);
+
+      const endCell = document.createElement('td');
+      endCell.textContent = formatDateTime(entry.endedAt);
+      row.appendChild(endCell);
+
+      const durationMs = Number.isFinite(entry.durationMs) ? entry.durationMs : 0;
+      totalDuration += Math.max(0, durationMs);
+      const durationCell = document.createElement('td');
+      durationCell.textContent = formatDuration(durationMs);
+      row.appendChild(durationCell);
+
+      const notesCell = document.createElement('td');
+      notesCell.textContent = entry.notes ? entry.notes : '–';
+      row.appendChild(notesCell);
+
+      const actionsCell = document.createElement('td');
+      actionsCell.classList.add('performance-table__actions');
+      const deleteButton = document.createElement('button');
+      deleteButton.type = 'button';
+      deleteButton.className = 'performance-table__action';
+      deleteButton.dataset.entryAction = 'delete';
+      deleteButton.dataset.entryId = entry.id;
+      deleteButton.textContent = 'Entfernen';
+      actionsCell.appendChild(deleteButton);
+      row.appendChild(actionsCell);
+
+      tableBody.appendChild(row);
+    });
+
+  totalDurationEl.textContent = formatDurationSummary(totalDuration);
+}
+
+function upsertCaseOptions() {
+  if (!caseSelect) {
+    return;
+  }
+
+  const dataEl = document.getElementById('time-tracking-case-data');
+  if (!dataEl) {
+    return;
+  }
+
+  try {
+    const raw = dataEl.textContent ?? '[]';
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return;
+    }
+
+    parsed
+      .map((item) => ({
+        caseNumber: String(item.caseNumber ?? '').trim(),
+        title: String(item.title ?? '').trim(),
+      }))
+      .filter((item) => item.caseNumber || item.title)
+      .forEach((item) => {
+        const option = document.createElement('option');
+        option.value = item.caseNumber;
+        option.textContent = item.title
+          ? `${item.caseNumber} – ${item.title}`
+          : item.caseNumber;
+        option.dataset.caseTitle = item.title;
+        caseSelect.appendChild(option);
+      });
+  } catch (error) {
+    console.error('Aktenliste für Zeiterfassung konnte nicht geladen werden.', error);
+    overlayInstance?.show?.({
+      title: 'Fehler beim Laden der Akten',
+      message: 'Die Aktenauswahl für die Zeiterfassung steht derzeit nicht zur Verfügung.',
+      details: error,
+    });
+  }
+}
+
+function getSelectedCaseTitle(caseNumber) {
+  if (!caseNumber || !caseSelect) {
+    return '';
+  }
+
+  const option = Array.from(caseSelect.options).find((item) => item.value === caseNumber);
+  return option?.dataset.caseTitle ?? '';
+}
+
+function handleStart() {
+  if (!activityInput) {
+    return;
+  }
+
+  const activity = activityInput.value.trim();
+  if (!activity) {
+    setStatus('Bitte geben Sie eine Tätigkeitsbeschreibung ein.', 'error');
+    activityInput.focus();
+    return;
+  }
+
+  if (stopwatchState !== 'idle') {
+    setStatus('Die Stoppuhr läuft bereits.', 'warning');
+    return;
+  }
+
+  stopwatchState = 'running';
+  startedAt = new Date();
+  accumulatedDurationMs = 0;
+  startHighResTimestamp = performance.now();
+  setButtonsState('running');
+  stopAnimation();
+  updateDisplay();
+
+  if (metaEl) {
+    metaEl.textContent = `Gestartet um ${new Intl.DateTimeFormat('de-DE', {
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(startedAt)} Uhr.`;
+  }
+
+  setStatus(`Zeiterfassung für „${activity}“ gestartet.`, 'success');
+}
+
+function handlePause() {
+  if (stopwatchState !== 'running') {
+    return;
+  }
+
+  accumulatedDurationMs += performance.now() - startHighResTimestamp;
+  stopwatchState = 'paused';
+  stopAnimation();
+  setButtonsState('paused');
+
+  if (metaEl) {
+    metaEl.textContent = 'Pausiert. Fortsetzen, um die Zeitnahme wieder aufzunehmen.';
+  }
+
+  setStatus('Zeiterfassung pausiert.', 'info');
+}
+
+function handleResume() {
+  if (stopwatchState !== 'paused') {
+    return;
+  }
+
+  stopwatchState = 'running';
+  startHighResTimestamp = performance.now();
+  setButtonsState('running');
+  stopAnimation();
+  updateDisplay();
+
+  if (metaEl) {
+    metaEl.textContent = `Fortgesetzt um ${new Intl.DateTimeFormat('de-DE', {
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date())} Uhr.`;
+  }
+
+  setStatus('Zeiterfassung fortgesetzt.', 'success');
+}
+
+function resetFormFields() {
+  if (!form) {
+    return;
+  }
+
+  form.reset();
+  if (activityInput) {
+    activityInput.focus();
+  }
+}
+
+function handleStop() {
+  if (stopwatchState !== 'running' && stopwatchState !== 'paused') {
+    return;
+  }
+
+  const finishedAt = new Date();
+  let durationMs = accumulatedDurationMs;
+  if (stopwatchState === 'running') {
+    durationMs += performance.now() - startHighResTimestamp;
+  }
+
+  durationMs = Math.round(Math.max(0, durationMs));
+
+  const activity = activityInput?.value.trim() ?? '';
+  const caseNumber = caseSelect?.value ?? '';
+  const notes = notesInput?.value.trim() ?? '';
+  const caseTitle = getSelectedCaseTitle(caseNumber);
+
+  const entry = {
+    id: generateEntryId(),
+    activity: activity || 'Ohne Titel',
+    caseNumber,
+    caseTitle,
+    notes,
+    startedAt: startedAt ? startedAt.toISOString() : finishedAt.toISOString(),
+    endedAt: finishedAt.toISOString(),
+    durationMs,
+    createdLabel: `Erfasst am ${formatDateTime(finishedAt)}`,
+  };
+
+  entries = [entry, ...entries.filter((item) => item && item.id !== entry.id)];
+  persistEntries();
+  renderEntries();
+
+  setStatus(`Eintrag „${entry.activity}“ wurde gespeichert.`, 'success');
+  resetFormFields();
+  resetStopwatch();
+  if (metaEl) {
+    metaEl.textContent = `Zuletzt gespeichert um ${new Intl.DateTimeFormat('de-DE', {
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(finishedAt)} Uhr.`;
+  }
+}
+
+function handleReset() {
+  resetStopwatch({ announce: true });
+}
+
+function handleDelete(event) {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  const action = target.dataset.entryAction;
+  if (action !== 'delete') {
+    return;
+  }
+
+  const id = target.dataset.entryId;
+  if (!id) {
+    return;
+  }
+
+  entries = entries.filter((entry) => entry.id !== id);
+  persistEntries();
+  renderEntries();
+  setStatus('Eintrag wurde entfernt.', 'info');
+}
+
+function handleStorageUpdate(event) {
+  if (event.key && event.key !== STORAGE_KEY) {
+    return;
+  }
+  loadEntries();
+  renderEntries();
+}
+
+function init() {
+  if (
+    !form ||
+    !activityInput ||
+    !caseSelect ||
+    !notesInput ||
+    !displayEl ||
+    !metaEl ||
+    !startButton ||
+    !pauseButton ||
+    !resumeButton ||
+    !stopButton ||
+    !resetButton ||
+    !tableBody ||
+    !emptyState ||
+    !entryCountEl ||
+    !totalDurationEl
+  ) {
+    return;
+  }
+
+  upsertCaseOptions();
+  loadEntries();
+  renderEntries();
+  setButtonsState('idle');
+
+  startButton.addEventListener('click', handleStart);
+  pauseButton.addEventListener('click', handlePause);
+  resumeButton.addEventListener('click', handleResume);
+  stopButton.addEventListener('click', handleStop);
+  resetButton.addEventListener('click', handleReset);
+  tableBody.addEventListener('click', handleDelete);
+  window.addEventListener('storage', handleStorageUpdate);
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
           <a class="btn btn-primary" href="mandate-wizard.html">Mandats-Wizard starten</a>
           <a class="btn btn-secondary" href="document-management.html">Dokumentenverwaltung</a>
           <a class="btn btn-secondary" href="template-assistant.html">Vorlagen-Assistent</a>
+          <a class="btn btn-secondary" href="time-tracking.html">Zeiterfassung</a>
         </div>
       </section>
 

--- a/time-tracking.html
+++ b/time-tracking.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Zeiterfassung</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Zeiterfassung</h1>
+      <p class="app-subtitle">Erfassen Sie Arbeitszeiten und behalten Sie Leistungen im Blick.</p>
+      <div class="welcome-actions">
+        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
+      </div>
+    </header>
+
+    <main class="app-main time-tracking-layout" aria-live="polite">
+      <section class="app-card time-tracking-card" aria-labelledby="time-tracking-title">
+        <div class="time-tracking-card__header">
+          <div>
+            <h2 id="time-tracking-title">Stoppuhr für Tätigkeiten</h2>
+            <p class="time-tracking-card__description">
+              Beschreiben Sie die Tätigkeit, wählen Sie optional eine Akte aus und starten Sie die Zeiterfassung.
+              Beim Stoppen wird automatisch ein Eintrag in der Leistungsübersicht erstellt.
+            </p>
+          </div>
+          <div class="time-tracking-card__status" id="time-tracking-status" role="status" aria-live="polite"></div>
+        </div>
+
+        <form class="time-tracking-form" id="time-tracking-form" novalidate>
+          <div class="form-field">
+            <label for="activity-title">Tätigkeitsbeschreibung <span aria-hidden="true">*</span></label>
+            <input
+              type="text"
+              id="activity-title"
+              name="activityTitle"
+              required
+              placeholder="z. B. Telefonat mit Mandant"
+              autocomplete="off"
+            />
+            <p class="form-hint" id="activity-title-hint">Beschreiben Sie die Tätigkeit so konkret wie möglich.</p>
+          </div>
+
+          <div class="form-field">
+            <label for="activity-case">Akte</label>
+            <select id="activity-case" name="activityCase" aria-describedby="activity-case-hint">
+              <option value="">Keine Zuordnung</option>
+            </select>
+            <p class="form-hint" id="activity-case-hint">Optional: Ordnen Sie die Zeit einer Akte zu.</p>
+          </div>
+
+          <div class="form-field">
+            <label for="activity-notes">Notizen</label>
+            <textarea
+              id="activity-notes"
+              name="activityNotes"
+              rows="3"
+              placeholder="Zusätzliche Informationen oder Ergebnisse"
+            ></textarea>
+          </div>
+        </form>
+
+        <div class="stopwatch" role="group" aria-labelledby="time-tracking-title">
+          <div class="stopwatch__display" id="stopwatch-display" aria-live="assertive">00:00:00</div>
+          <p class="stopwatch__meta" id="stopwatch-meta" aria-live="polite">Noch nicht gestartet.</p>
+          <div class="stopwatch__controls">
+            <button type="button" class="btn btn-primary" id="stopwatch-start">Starten</button>
+            <button type="button" class="btn btn-secondary" id="stopwatch-pause" disabled>Pausieren</button>
+            <button type="button" class="btn btn-secondary" id="stopwatch-resume" hidden disabled>Fortsetzen</button>
+            <button type="button" class="btn btn-secondary" id="stopwatch-stop" disabled>Stoppen &amp; speichern</button>
+            <button type="button" class="btn" id="stopwatch-reset" disabled>Zurücksetzen</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="app-card performance-card" aria-labelledby="performance-title">
+        <header class="performance-card__header">
+          <div>
+            <h2 id="performance-title">Leistungsübersicht</h2>
+            <p class="performance-card__description">
+              Alle erfassten Zeitbucheinträge werden hier gesammelt. Nutzen Sie die Summenanzeige, um die Tagesleistung einzuschätzen.
+            </p>
+          </div>
+          <dl class="performance-summary" aria-label="Zusammenfassung der erfassten Zeit">
+            <div class="performance-summary__item">
+              <dt>Einträge</dt>
+              <dd id="performance-entry-count">0</dd>
+            </div>
+            <div class="performance-summary__item">
+              <dt>Gesamtzeit</dt>
+              <dd id="performance-total-duration">00:00 h</dd>
+            </div>
+          </dl>
+        </header>
+
+        <div class="table-wrapper" role="region" aria-live="polite" aria-labelledby="performance-title">
+          <table class="performance-table">
+            <thead>
+              <tr>
+                <th scope="col">Tätigkeit</th>
+                <th scope="col">Akte</th>
+                <th scope="col">Start</th>
+                <th scope="col">Ende</th>
+                <th scope="col">Dauer</th>
+                <th scope="col">Notiz</th>
+                <th scope="col" class="performance-table__actions">Aktionen</th>
+              </tr>
+            </thead>
+            <tbody id="performance-table-body"></tbody>
+          </table>
+        </div>
+        <p id="performance-empty-state" class="performance-empty-state">Noch keine Einträge vorhanden. Starten Sie die Stoppuhr, um die erste Leistung zu erfassen.</p>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details">
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">Seite neu laden</button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">Schließen</button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="application/json" id="time-tracking-case-data">
+      [
+        { "caseNumber": "V-2024-001", "title": "Vertragsprüfung Müller GmbH" },
+        { "caseNumber": "A-2024-017", "title": "Arbeitsrechtliche Beratung Schmidt" },
+        { "caseNumber": "I-2024-004", "title": "Investitionsprüfung GreenTech" },
+        { "caseNumber": "M-2023-089", "title": "Mietrechtliche Streitigkeit Weber" },
+        { "caseNumber": "S-2024-032", "title": "Steuerprüfung Contoso AG" }
+      ]
+    </script>
+
+    <script src="assets/js/app.js" type="module"></script>
+    <script src="assets/js/time-tracking.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create a dedicated time-tracking page with stopwatch controls and a linked performance overview
- implement client-side logic to persist entries, handle pause/resume, and manage stored performance data
- style the new interface elements and link the page from the landing screen while updating the project ToDo list

## Testing
- Manual QA via local browser session

------
https://chatgpt.com/codex/tasks/task_e_690b088967b483208e3d83aaaef250fc