### PR TITLE
Add performance overview page with filtering and summaries

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -44,7 +44,7 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
    Status: ✅ erledigt – 2025-11-05
 
 10. **Leistungsübersicht** – Erstelle eine Tabelle aller Leistungen mit Filter- und Summenfunktion (z. B. Stunden nach Mandant).  
-    Status: ⬜
+    Status: ✅ erledigt – 2025-11-05
 
 11. **Rechnungs-Wizard** – Baue einen Wizard zur Rechnungserstellung auf Basis erfasster Leistungen. Zeige Vorschau und PDF-Export (Dummy).  
     Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -43,6 +43,12 @@ body {
   box-sizing: border-box;
 }
 
+.performance-overview-main {
+  width: min(1100px, 100%);
+  align-self: center;
+  align-items: stretch;
+}
+
 
 .app-card {
   width: min(650px, 100%);
@@ -145,6 +151,132 @@ body {
   margin: 0.35rem 0 0;
   max-width: 36rem;
   color: #4b5563;
+}
+
+.performance-overview {
+  width: 100%;
+  background: #fff;
+  border-radius: 18px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(31, 60, 136, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.performance-overview__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(1rem, 3vw, 2rem);
+}
+
+.performance-overview__description {
+  margin: 0.35rem 0 0;
+  max-width: 60ch;
+  color: #4b5563;
+}
+
+.performance-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem clamp(1rem, 3vw, 1.5rem);
+  background: rgba(47, 116, 192, 0.06);
+  border-radius: 16px;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  border: 1px solid rgba(47, 116, 192, 0.12);
+}
+
+.performance-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.performance-filter__label {
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #1f3c88;
+  font-weight: 600;
+}
+
+.performance-filter input,
+.performance-filter select {
+  border-radius: 12px;
+  border: 1px solid rgba(31, 60, 136, 0.15);
+  padding: 0.65rem 0.85rem;
+  font-size: 1rem;
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.performance-filter input:focus-visible,
+.performance-filter select:focus-visible {
+  outline: none;
+  border-color: #2f74c0;
+  box-shadow: 0 0 0 3px rgba(47, 116, 192, 0.18);
+}
+
+.performance-breakdown {
+  background: rgba(47, 116, 192, 0.05);
+  border-radius: 18px;
+  border: 1px solid rgba(47, 116, 192, 0.12);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.performance-breakdown__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.performance-breakdown__summary {
+  margin: 0;
+  color: #4b5563;
+}
+
+.performance-breakdown__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.performance-breakdown__item {
+  background: #fff;
+  border-radius: 14px;
+  border: 1px solid rgba(47, 116, 192, 0.12);
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.35rem;
+  min-height: 96px;
+}
+
+.performance-breakdown__item h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: #1f3c88;
+}
+
+.performance-breakdown__metric {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.performance-breakdown__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6b7280;
 }
 
 .document-manager-main {
@@ -2055,6 +2187,18 @@ body {
 
   .stopwatch {
     padding: 1.25rem;
+  }
+
+  .performance-overview__header {
+    flex-direction: column;
+  }
+
+  .performance-filters {
+    grid-template-columns: 1fr;
+  }
+
+  .performance-breakdown__list {
+    grid-template-columns: 1fr;
   }
 
   .performance-summary {

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
           <a class="btn btn-secondary" href="document-management.html">Dokumentenverwaltung</a>
           <a class="btn btn-secondary" href="template-assistant.html">Vorlagen-Assistent</a>
           <a class="btn btn-secondary" href="time-tracking.html">Zeiterfassung</a>
+          <a class="btn btn-secondary" href="performance-overview.html">Leistungsübersicht</a>
         </div>
       </section>
 

--- a/performance-overview.html
+++ b/performance-overview.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Leistungsübersicht</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Leistungsübersicht</h1>
+      <p class="app-subtitle">
+        Analysieren Sie erfasste Tätigkeiten, filtern Sie nach Mandanten und behalten Sie Summen im Blick.
+      </p>
+      <div class="welcome-actions">
+        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
+        <a class="btn btn-secondary" href="time-tracking.html">Zur Zeiterfassung</a>
+      </div>
+    </header>
+
+    <main class="app-main performance-overview-main" aria-live="polite">
+      <section class="performance-overview" aria-labelledby="performance-overview-title">
+        <header class="performance-overview__header">
+          <div>
+            <h2 id="performance-overview-title">Gefilterte Leistungsdaten</h2>
+            <p class="performance-overview__description">
+              Die Liste basiert auf den Zeitbucheinträgen der Zeiterfassung. Nutzen Sie die Filter, um sich auf Mandanten, Zeiträume
+              oder Tätigkeiten zu konzentrieren.
+            </p>
+          </div>
+          <dl class="performance-summary" aria-label="Zusammenfassung der gefilterten Leistungen">
+            <div class="performance-summary__item">
+              <dt>Einträge</dt>
+              <dd id="overview-entry-count">0</dd>
+            </div>
+            <div class="performance-summary__item">
+              <dt>Gesamtzeit</dt>
+              <dd id="overview-total-duration">00:00 h</dd>
+            </div>
+            <div class="performance-summary__item">
+              <dt>Ø Dauer</dt>
+              <dd id="overview-average-duration">00:00 h</dd>
+            </div>
+          </dl>
+        </header>
+
+        <form class="performance-filters" aria-label="Leistungsdaten filtern" novalidate>
+          <div class="performance-filter">
+            <label class="performance-filter__label" for="performance-search">Suche</label>
+            <input
+              type="search"
+              id="performance-search"
+              name="search"
+              placeholder="Nach Tätigkeit, Akte oder Notiz suchen"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
+          <div class="performance-filter">
+            <label class="performance-filter__label" for="performance-client-filter">Mandant</label>
+            <select id="performance-client-filter" name="client">
+              <option value="">Alle Mandanten</option>
+            </select>
+          </div>
+          <div class="performance-filter">
+            <label class="performance-filter__label" for="performance-period-filter">Zeitraum</label>
+            <select id="performance-period-filter" name="period">
+              <option value="all">Alle Einträge</option>
+              <option value="today">Heute</option>
+              <option value="week">Diese Woche</option>
+              <option value="month">Diesen Monat</option>
+              <option value="last30">Letzte 30 Tage</option>
+            </select>
+          </div>
+        </form>
+
+        <section class="performance-breakdown" aria-labelledby="performance-breakdown-title">
+          <div class="performance-breakdown__header">
+            <h3 id="performance-breakdown-title">Summen nach Mandant</h3>
+            <p id="performance-breakdown-summary" class="performance-breakdown__summary">
+              Keine Daten vorhanden.
+            </p>
+          </div>
+          <ul id="performance-breakdown-list" class="performance-breakdown__list" role="list"></ul>
+        </section>
+
+        <div class="table-wrapper" role="region" aria-live="polite" aria-labelledby="performance-overview-title">
+          <table class="performance-table">
+            <thead>
+              <tr>
+                <th scope="col">Tätigkeit</th>
+                <th scope="col">Mandant</th>
+                <th scope="col">Akte</th>
+                <th scope="col">Start</th>
+                <th scope="col">Ende</th>
+                <th scope="col">Dauer</th>
+                <th scope="col">Notiz</th>
+              </tr>
+            </thead>
+            <tbody id="performance-overview-table-body"></tbody>
+          </table>
+        </div>
+        <p id="performance-overview-empty-state" class="performance-empty-state" hidden>
+          Es sind keine Leistungen für die aktuelle Filterauswahl vorhanden.
+        </p>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details">
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">Seite neu laden</button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">Schließen</button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="application/json" id="performance-case-data">
+      [
+        {
+          "caseNumber": "V-2024-001",
+          "title": "Vertragsprüfung Müller GmbH",
+          "client": "Müller GmbH"
+        },
+        {
+          "caseNumber": "A-2024-017",
+          "title": "Arbeitsrechtliche Beratung Schmidt",
+          "client": "Eva Schmidt"
+        },
+        {
+          "caseNumber": "I-2024-004",
+          "title": "Investitionsprüfung GreenTech",
+          "client": "GreenTech Holding"
+        },
+        {
+          "caseNumber": "M-2023-089",
+          "title": "Mietrechtliche Streitigkeit Weber",
+          "client": "Jonas Weber"
+        },
+        {
+          "caseNumber": "S-2024-032",
+          "title": "Steuerprüfung Contoso AG",
+          "client": "Contoso AG"
+        },
+        {
+          "caseNumber": "F-2024-011",
+          "title": "Familienrechtliche Mediation Krause",
+          "client": "Familie Krause"
+        }
+      ]
+    </script>
+
+    <script src="assets/js/app.js" type="module"></script>
+    <script src="assets/js/performance-overview.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone performance overview page that reads stored time entries, supports filters, and shows per-client breakdowns
- introduce styling for the new overview layout and link it from the start page navigation
- mark the corresponding task as completed in the project ToDo list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b0af038148320a106653828b7576d