### PR TITLE
Implement invoice wizard with billing preview

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -46,8 +46,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 10. **Leistungsübersicht** – Erstelle eine Tabelle aller Leistungen mit Filter- und Summenfunktion (z. B. Stunden nach Mandant).  
     Status: ✅ erledigt – 2025-11-05
 
-11. **Rechnungs-Wizard** – Baue einen Wizard zur Rechnungserstellung auf Basis erfasster Leistungen. Zeige Vorschau und PDF-Export (Dummy).  
-    Status: ⬜
+11. **Rechnungs-Wizard** – Baue einen Wizard zur Rechnungserstellung auf Basis erfasster Leistungen. Zeige Vorschau und PDF-Export (Dummy).
+    Status: ✅ erledigt – 2025-11-05
 
 12. **Offene-Posten-Übersicht (Mock)** – Zeige Rechnungen mit Status „bezahlt“, „überfällig“, „offen“. Keine echte Datenbank nötig.  
     Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2218,3 +2218,191 @@ body {
     text-align: left;
   }
 }
+.form-field__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.form-field--wide {
+  grid-column: 1 / -1;
+}
+
+.invoice-summary {
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(47, 116, 192, 0.05);
+  border: 1px solid rgba(47, 116, 192, 0.12);
+  border-radius: 16px;
+  padding: 1.25rem;
+}
+
+.invoice-summary__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.invoice-summary__label {
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.invoice-summary__value {
+  font-variant-numeric: tabular-nums;
+}
+
+.invoice-summary__empty {
+  margin: 0;
+  color: #b45309;
+  font-weight: 600;
+}
+
+.invoice-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: 12px;
+  border: 1px solid rgba(31, 60, 136, 0.1);
+  background: #fff;
+}
+
+.invoice-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 600px;
+}
+
+.invoice-table th,
+.invoice-table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.invoice-table th {
+  background: rgba(47, 116, 192, 0.08);
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.invoice-table td {
+  vertical-align: top;
+}
+
+.invoice-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.invoice-empty-state {
+  margin: 1rem 0 0;
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.invoice-totals {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0 0;
+}
+
+.invoice-totals__item {
+  background: rgba(15, 23, 42, 0.03);
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.invoice-totals__item--highlight {
+  background: rgba(22, 163, 74, 0.12);
+  border: 1px solid rgba(22, 163, 74, 0.35);
+}
+
+.invoice-totals__item dt {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #475569;
+}
+
+.invoice-totals__item dd {
+  margin: 0;
+  font-size: 1.1rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.invoice-line__title {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.invoice-line__meta {
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.invoice-line__notes {
+  margin-top: 0.35rem;
+  color: #475569;
+}
+
+.invoice-line__rate {
+  width: 100%;
+  max-width: 140px;
+  padding: 0.5rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  font-size: 1rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.invoice-preview {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.invoice-preview__meta {
+  margin: 0;
+  color: #475569;
+}
+
+.invoice-preview__notes {
+  white-space: pre-wrap;
+  margin: 0;
+  color: #1f2937;
+}
+
+.invoice-preview__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.invoice-table--preview {
+  min-width: 100%;
+}
+
+.invoice-totals--preview {
+  margin-top: 0;
+}
+
+@media (max-width: 720px) {
+  .invoice-summary__row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .invoice-table {
+    min-width: 100%;
+  }
+
+  .invoice-totals {
+    grid-template-columns: 1fr;
+  }
+
+  .invoice-preview__actions {
+    justify-content: center;
+  }
+}

--- a/assets/js/invoice-wizard.js
+++ b/assets/js/invoice-wizard.js
@@ -1,0 +1,1029 @@
+import { overlayInstance } from './app.js';
+
+const STORAGE_KEY = 'verilex:time-entries';
+const form = document.getElementById('invoice-form');
+
+if (!form) {
+  console.warn('Invoice wizard form not found.');
+}
+
+const progressContainer = document.querySelector('.wizard-progress');
+const steps = Array.from(form?.querySelectorAll('.wizard-step') ?? []);
+const prevButton = document.getElementById('invoice-prev');
+const nextButton = document.getElementById('invoice-next');
+const submitButton = document.getElementById('invoice-submit');
+const successMessage = document.getElementById('invoice-success');
+const resetButton = document.getElementById('invoice-reset');
+const exportButton = document.getElementById('invoice-export');
+
+const clientSelect = document.getElementById('invoice-client');
+const periodSelect = document.getElementById('invoice-period');
+const caseSelect = document.getElementById('invoice-case-filter');
+const summaryEl = document.getElementById('invoice-filter-summary');
+const step1ErrorEl = document.getElementById('invoice-step1-error');
+const clientErrorEl = document.getElementById('invoice-client-error');
+
+const itemsTableBody = document.getElementById('invoice-line-items');
+const itemsEmptyEl = document.getElementById('invoice-items-empty');
+const itemsErrorEl = document.getElementById('invoice-items-error');
+const totalHoursEl = document.getElementById('invoice-total-hours');
+const totalNetEl = document.getElementById('invoice-total-net');
+const totalTaxEl = document.getElementById('invoice-total-tax');
+const totalGrossEl = document.getElementById('invoice-total-gross');
+
+const invoiceNumberInput = document.getElementById('invoice-number');
+const invoiceNumberError = document.getElementById('invoice-number-error');
+const invoiceDateInput = document.getElementById('invoice-date');
+const invoiceDateError = document.getElementById('invoice-date-error');
+const dueDateInput = document.getElementById('invoice-due-date');
+const dueDateError = document.getElementById('invoice-due-date-error');
+const taxRateInput = document.getElementById('invoice-tax-rate');
+const taxRateError = document.getElementById('invoice-tax-rate-error');
+const referenceInput = document.getElementById('invoice-reference');
+const paymentTermsInput = document.getElementById('invoice-payment-terms');
+const notesInput = document.getElementById('invoice-notes');
+
+const previewMetaEl = document.getElementById('invoice-preview-meta');
+const previewClientEl = document.getElementById('invoice-preview-client');
+const previewCaseEl = document.getElementById('invoice-preview-case');
+const previewPeriodEl = document.getElementById('invoice-preview-period');
+const previewDueEl = document.getElementById('invoice-preview-due');
+const previewItemsBody = document.getElementById('invoice-preview-items');
+const previewNetEl = document.getElementById('invoice-preview-net');
+const previewTaxEl = document.getElementById('invoice-preview-tax');
+const previewGrossEl = document.getElementById('invoice-preview-gross');
+const previewNotesEl = document.getElementById('invoice-preview-notes');
+
+const state = {
+  activeStep: 1,
+  maxStep: 4,
+  entries: [],
+  filteredEntries: [],
+  lineItems: [],
+  selectedEntryIds: [],
+  caseDirectory: new Map(),
+  selectedClient: '',
+  selectedCase: '',
+  selectedPeriod: 'all',
+  invoiceDetails: {
+    number: '',
+    invoiceDate: '',
+    dueDate: '',
+    taxRate: 19,
+    reference: '',
+    paymentTerms: '',
+    notes: '',
+  },
+};
+
+function formatCurrency(value) {
+  const number = Number.isFinite(value) ? value : 0;
+  return new Intl.NumberFormat('de-DE', {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 2,
+  }).format(number);
+}
+
+function formatHours(value) {
+  const number = Number.isFinite(value) ? value : 0;
+  return `${number.toFixed(2)} h`;
+}
+
+function formatDate(value) {
+  if (!value) {
+    return '–';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '–';
+  }
+  return new Intl.DateTimeFormat('de-DE', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+function formatDateRange(start, end) {
+  if (!start && !end) {
+    return 'Gesamter Leistungszeitraum';
+  }
+
+  const formattedStart = formatDate(start);
+  const formattedEnd = formatDate(end);
+  if (formattedStart === '–') {
+    return `bis ${formattedEnd}`;
+  }
+  if (formattedEnd === '–') {
+    return `ab ${formattedStart}`;
+  }
+  return `${formattedStart} – ${formattedEnd}`;
+}
+
+function parseJSONElement(elementId) {
+  const element = document.getElementById(elementId);
+  if (!element) {
+    return null;
+  }
+  try {
+    const raw = element.textContent ?? 'null';
+    return JSON.parse(raw);
+  } catch (error) {
+    console.error(`JSON payload in element #${elementId} is invalid.`, error);
+    overlayInstance?.show?.({
+      title: 'Daten konnten nicht geladen werden',
+      message: 'Ein eingebetteter Datensatz für den Rechnungs-Wizard ist fehlerhaft.',
+      details: error,
+    });
+    return null;
+  }
+}
+
+function generateInternalId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `invoice-${Math.random().toString(16).slice(2)}-${Date.now()}`;
+}
+
+function normalizeEntry(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const durationMs = Number(raw.durationMs);
+  const caseNumber = typeof raw.caseNumber === 'string' ? raw.caseNumber.trim() : '';
+  const directoryInfo = state.caseDirectory.get(caseNumber);
+
+  const normalized = {
+    id:
+      typeof raw.id === 'string' && raw.id.trim() ? raw.id.trim() : generateInternalId(),
+    activity:
+      typeof raw.activity === 'string' && raw.activity.trim()
+        ? raw.activity.trim()
+        : 'Ohne Titel',
+    caseNumber,
+    caseTitle:
+      typeof raw.caseTitle === 'string' && raw.caseTitle.trim()
+        ? raw.caseTitle.trim()
+        : directoryInfo?.title ?? '',
+    client:
+      typeof raw.client === 'string' && raw.client.trim()
+        ? raw.client.trim()
+        : directoryInfo?.client ?? 'Unzugeordneter Mandant',
+    durationMs: Number.isFinite(durationMs) ? Math.max(0, durationMs) : 0,
+    endedAt: raw.endedAt ?? raw.ended_at ?? null,
+    notes: typeof raw.notes === 'string' ? raw.notes.trim() : '',
+    rate: Number.isFinite(Number(raw.rate))
+      ? Number(raw.rate)
+      : Number(directoryInfo?.defaultRate ?? 180),
+  };
+
+  if (!normalized.caseNumber && directoryInfo?.caseNumber) {
+    normalized.caseNumber = directoryInfo.caseNumber;
+  }
+
+  return normalized;
+}
+
+function loadCaseDirectory() {
+  const directoryData = parseJSONElement('invoice-case-directory');
+  if (!Array.isArray(directoryData)) {
+    return;
+  }
+
+  directoryData
+    .map((entry) => ({
+      caseNumber: typeof entry.caseNumber === 'string' ? entry.caseNumber.trim() : '',
+      title: typeof entry.title === 'string' ? entry.title.trim() : '',
+      client: typeof entry.client === 'string' ? entry.client.trim() : 'Unbekannter Mandant',
+      defaultRate: Number.isFinite(Number(entry.defaultRate))
+        ? Number(entry.defaultRate)
+        : undefined,
+    }))
+    .filter((entry) => entry.caseNumber)
+    .forEach((entry) => {
+      state.caseDirectory.set(entry.caseNumber, entry);
+    });
+}
+
+function loadEntries() {
+  const storageEntries = loadEntriesFromStorage();
+  if (storageEntries.length > 0) {
+    return storageEntries;
+  }
+
+  const fallbackEntries = parseJSONElement('invoice-entry-data');
+  if (!Array.isArray(fallbackEntries)) {
+    return [];
+  }
+
+  return fallbackEntries
+    .map((entry) => normalizeEntry(entry))
+    .filter((entry) => entry !== null);
+}
+
+function loadEntriesFromStorage() {
+  if (typeof localStorage === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((entry) => normalizeEntry(entry))
+      .filter((entry) => entry !== null);
+  } catch (error) {
+    console.error('Invoice wizard could not parse stored time entries.', error);
+    overlayInstance?.show?.({
+      title: 'Gespeicherte Leistungen nicht verfügbar',
+      message:
+        'Die im Browser gespeicherten Leistungsdaten konnten nicht geladen werden. Es werden Demo-Daten verwendet.',
+      details: error,
+    });
+    return [];
+  }
+}
+
+function setFieldError(field, errorElement, message) {
+  if (!field || !errorElement) {
+    return;
+  }
+
+  if (message) {
+    field.classList.add('is-invalid');
+    errorElement.textContent = message;
+  } else {
+    field.classList.remove('is-invalid');
+    errorElement.textContent = '';
+  }
+}
+
+function clearStepMessages() {
+  if (itemsErrorEl) {
+    itemsErrorEl.textContent = '';
+  }
+  if (step1ErrorEl) {
+    step1ErrorEl.textContent = '';
+  }
+  if (clientErrorEl) {
+    clientErrorEl.textContent = '';
+  }
+}
+
+function updateProgressIndicator(activeIndex) {
+  if (!progressContainer) {
+    return;
+  }
+
+  const stepsElements = Array.from(progressContainer.querySelectorAll('[data-progress-step]'));
+  stepsElements.forEach((stepEl) => {
+    const stepIndex = Number.parseInt(stepEl.dataset.progressStep ?? '0', 10);
+    stepEl.classList.toggle('wizard-progress__step--current', stepIndex === activeIndex);
+    stepEl.classList.toggle('wizard-progress__step--completed', stepIndex < activeIndex);
+    stepEl.classList.toggle('wizard-progress__step--upcoming', stepIndex > activeIndex);
+    if (stepIndex === activeIndex) {
+      stepEl.setAttribute('aria-current', 'step');
+    } else {
+      stepEl.removeAttribute('aria-current');
+    }
+  });
+
+  progressContainer.setAttribute(
+    'aria-label',
+    `Fortschritt Rechnungs-Wizard: Schritt ${activeIndex} von ${state.maxStep}`
+  );
+}
+
+function showStep(targetStep) {
+  if (!steps.length) {
+    return;
+  }
+
+  const clampedStep = Math.min(Math.max(1, targetStep), state.maxStep);
+  state.activeStep = clampedStep;
+
+  steps.forEach((section) => {
+    const stepIndex = Number.parseInt(section.dataset.step ?? '0', 10);
+    const isActive = stepIndex === clampedStep;
+    section.toggleAttribute('hidden', !isActive);
+    if (isActive) {
+      section.querySelector('.wizard-step__title')?.focus?.();
+    }
+  });
+
+  if (prevButton) {
+    prevButton.disabled = clampedStep === 1;
+  }
+  if (nextButton) {
+    nextButton.hidden = clampedStep === state.maxStep;
+  }
+  if (submitButton) {
+    submitButton.hidden = clampedStep !== state.maxStep;
+  }
+
+  updateProgressIndicator(clampedStep);
+
+  if (clampedStep === 2) {
+    renderLineItems();
+  } else if (clampedStep === 4) {
+    updatePreview();
+  }
+}
+
+function parsePeriodSelection() {
+  const value = periodSelect?.value ?? 'all';
+  const now = new Date();
+  const end = now;
+
+  if (value === 'all') {
+    return { start: null, end: null };
+  }
+
+  const days = Number.parseInt(value, 10);
+  if (!Number.isFinite(days) || days <= 0) {
+    return { start: null, end: null };
+  }
+
+  const start = new Date(now);
+  start.setDate(now.getDate() - days);
+  return { start, end };
+}
+
+function filterEntries() {
+  const client = clientSelect?.value ?? '';
+  const caseNumber = caseSelect?.value ?? '';
+  const { start, end } = parsePeriodSelection();
+
+  if (step1ErrorEl) {
+    step1ErrorEl.textContent = '';
+  }
+  if (itemsErrorEl) {
+    itemsErrorEl.textContent = '';
+  }
+
+  state.selectedClient = client;
+  state.selectedCase = caseNumber;
+  state.selectedPeriod = periodSelect?.value ?? 'all';
+
+  const hasStart = start instanceof Date && !Number.isNaN(start.getTime());
+  const hasEnd = end instanceof Date && !Number.isNaN(end.getTime());
+
+  state.filteredEntries = state.entries.filter((entry) => {
+    if (client && entry.client !== client) {
+      return false;
+    }
+    if (caseNumber && entry.caseNumber !== caseNumber) {
+      return false;
+    }
+
+    if (!hasStart && !hasEnd) {
+      return true;
+    }
+
+    const endedAt = entry.endedAt ? new Date(entry.endedAt) : null;
+    if (!endedAt || Number.isNaN(endedAt.getTime())) {
+      return false;
+    }
+
+    if (hasStart && endedAt < start) {
+      return false;
+    }
+
+    if (hasEnd && endedAt > end) {
+      return false;
+    }
+
+    return true;
+  });
+
+  prepareLineItems();
+  updateFilterSummary();
+}
+
+function prepareLineItems() {
+  state.lineItems = state.filteredEntries.map((entry) => {
+    const hours = entry.durationMs / 3600000;
+    const roundedHours = Number.isFinite(hours) ? Math.max(0, hours) : 0;
+    const rate = Number.isFinite(entry.rate) ? Math.max(0, entry.rate) : 0;
+    return {
+      id: entry.id,
+      description: entry.activity,
+      caseTitle: entry.caseTitle,
+      caseNumber: entry.caseNumber,
+      client: entry.client,
+      hours: roundedHours,
+      rate,
+      amount: roundedHours * rate,
+      endedAt: entry.endedAt,
+      notes: entry.notes,
+    };
+  });
+
+  state.selectedEntryIds = state.lineItems.map((item) => item.id);
+  updateTotals();
+}
+
+function updateFilterSummary() {
+  if (!summaryEl) {
+    return;
+  }
+
+  if (!state.filteredEntries.length) {
+    summaryEl.innerHTML = `
+      <p class="invoice-summary__empty">
+        Für die aktuelle Auswahl wurden keine Leistungen gefunden.
+      </p>
+    `;
+    return;
+  }
+
+  const hours = state.lineItems.reduce((sum, item) => sum + item.hours, 0);
+  const net = state.lineItems.reduce((sum, item) => sum + item.amount, 0);
+  const period = parsePeriodSelection();
+
+  summaryEl.innerHTML = `
+    <div class="invoice-summary__row">
+      <span class="invoice-summary__label">Vorausgewählte Leistungen</span>
+      <span class="invoice-summary__value">${state.filteredEntries.length}</span>
+    </div>
+    <div class="invoice-summary__row">
+      <span class="invoice-summary__label">Zeitraum</span>
+      <span class="invoice-summary__value">${formatDateRange(period.start, period.end)}</span>
+    </div>
+    <div class="invoice-summary__row">
+      <span class="invoice-summary__label">Stunden (gesamt)</span>
+      <span class="invoice-summary__value">${hours.toFixed(2)} h</span>
+    </div>
+    <div class="invoice-summary__row">
+      <span class="invoice-summary__label">Zwischensumme</span>
+      <span class="invoice-summary__value">${formatCurrency(net)}</span>
+    </div>
+  `;
+}
+
+function updateTotals() {
+  const taxRate = getTaxRate();
+  const selectedItems = state.lineItems.filter((item) =>
+    state.selectedEntryIds.includes(item.id)
+  );
+
+  const totalHours = selectedItems.reduce((sum, item) => sum + item.hours, 0);
+  const net = selectedItems.reduce((sum, item) => sum + item.hours * item.rate, 0);
+  const tax = net * (taxRate / 100);
+  const gross = net + tax;
+
+  if (totalHoursEl) {
+    totalHoursEl.textContent = `${totalHours.toFixed(2)} h`;
+  }
+  if (totalNetEl) {
+    totalNetEl.textContent = formatCurrency(net);
+  }
+  if (totalTaxEl) {
+    totalTaxEl.textContent = formatCurrency(tax);
+  }
+  if (totalGrossEl) {
+    totalGrossEl.textContent = formatCurrency(gross);
+  }
+}
+
+function getTaxRate() {
+  const raw = taxRateInput?.value ?? `${state.invoiceDetails.taxRate}`;
+  const parsed = Number.parseFloat(raw);
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    state.invoiceDetails.taxRate = parsed;
+    return parsed;
+  }
+  return state.invoiceDetails.taxRate;
+}
+
+function renderLineItems() {
+  if (!itemsTableBody || !itemsEmptyEl) {
+    return;
+  }
+
+  itemsTableBody.innerHTML = '';
+
+  if (!state.lineItems.length) {
+    itemsEmptyEl.hidden = false;
+    return;
+  }
+
+  itemsEmptyEl.hidden = true;
+
+  state.lineItems.forEach((item, index) => {
+    const row = document.createElement('tr');
+    row.dataset.entryId = item.id;
+
+    const selectionCell = document.createElement('td');
+    const selectionId = `line-item-${index}`;
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = selectionId;
+    checkbox.className = 'invoice-line-toggle';
+    checkbox.dataset.entryId = item.id;
+    checkbox.checked = state.selectedEntryIds.includes(item.id);
+    const selectionLabel = document.createElement('label');
+    selectionLabel.htmlFor = selectionId;
+    selectionLabel.className = 'visually-hidden';
+    selectionLabel.textContent = 'Leistung für Rechnung berücksichtigen';
+    selectionCell.appendChild(checkbox);
+    selectionCell.appendChild(selectionLabel);
+    row.appendChild(selectionCell);
+
+    const descriptionCell = document.createElement('td');
+    descriptionCell.innerHTML = `
+      <div class="invoice-line__title">${item.description}</div>
+      <div class="invoice-line__meta">
+        ${item.caseTitle || 'Ohne Aktenbezug'}
+        ${item.caseNumber ? ` · ${item.caseNumber}` : ''}
+        ${item.endedAt ? ` · ${formatDate(item.endedAt)}` : ''}
+      </div>
+      ${item.notes ? `<div class="invoice-line__notes">${item.notes}</div>` : ''}
+    `;
+    row.appendChild(descriptionCell);
+
+    const durationCell = document.createElement('td');
+    durationCell.textContent = formatHours(item.hours);
+    row.appendChild(durationCell);
+
+    const rateCell = document.createElement('td');
+    const rateInput = document.createElement('input');
+    rateInput.type = 'number';
+    rateInput.min = '0';
+    rateInput.step = '5';
+    rateInput.value = item.rate.toFixed(2);
+    rateInput.dataset.entryId = item.id;
+    rateInput.className = 'invoice-line__rate';
+    rateCell.appendChild(rateInput);
+    row.appendChild(rateCell);
+
+    const amountCell = document.createElement('td');
+    amountCell.dataset.role = 'amount';
+    amountCell.textContent = formatCurrency(item.hours * item.rate);
+    row.appendChild(amountCell);
+
+    itemsTableBody.appendChild(row);
+  });
+}
+
+function updateAmountDisplay(entryId) {
+  const row = itemsTableBody?.querySelector(`tr[data-entry-id="${entryId}"]`);
+  if (!row) {
+    return;
+  }
+  const amountCell = row.querySelector('[data-role="amount"]');
+  const item = state.lineItems.find((line) => line.id === entryId);
+  if (amountCell && item) {
+    amountCell.textContent = formatCurrency(item.hours * item.rate);
+  }
+}
+
+function validateStep(stepIndex) {
+  clearStepMessages();
+
+  if (stepIndex === 1) {
+    if (!clientSelect || !clientSelect.value) {
+      if (clientSelect) {
+        setFieldError(clientSelect, clientErrorEl, 'Bitte wählen Sie einen Mandanten aus.');
+        clientSelect.focus();
+      }
+      step1ErrorEl.textContent = 'Ohne Mandant kann keine Rechnung erstellt werden.';
+      return false;
+    }
+
+    if (!state.filteredEntries.length) {
+      step1ErrorEl.textContent =
+        'Für diese Kombination aus Mandant, Zeitraum und Akte liegen keine Leistungen vor.';
+      return false;
+    }
+
+    setFieldError(clientSelect, clientErrorEl, '');
+    return true;
+  }
+
+  if (stepIndex === 2) {
+    if (!state.selectedEntryIds.length) {
+      itemsErrorEl.textContent = 'Bitte wählen Sie mindestens eine Leistung aus.';
+      return false;
+    }
+
+    const invalidRate = state.lineItems.find((item) => item.rate <= 0);
+    if (invalidRate) {
+      itemsErrorEl.textContent = 'Die Stundensätze müssen größer als 0 sein.';
+      return false;
+    }
+
+    return true;
+  }
+
+  if (stepIndex === 3) {
+    let isValid = true;
+
+    if (!invoiceNumberInput || !invoiceNumberInput.value.trim()) {
+      setFieldError(invoiceNumberInput, invoiceNumberError, 'Bitte geben Sie eine Rechnungsnummer ein.');
+      invoiceNumberInput?.focus();
+      isValid = false;
+    } else {
+      setFieldError(invoiceNumberInput, invoiceNumberError, '');
+    }
+
+    if (!invoiceDateInput || !invoiceDateInput.value) {
+      setFieldError(invoiceDateInput, invoiceDateError, 'Bitte wählen Sie ein Rechnungsdatum.');
+      if (isValid) {
+        invoiceDateInput?.focus();
+      }
+      isValid = false;
+    } else {
+      setFieldError(invoiceDateInput, invoiceDateError, '');
+    }
+
+    if (!dueDateInput || !dueDateInput.value) {
+      setFieldError(dueDateInput, dueDateError, 'Bitte wählen Sie ein Fälligkeitsdatum.');
+      if (isValid) {
+        dueDateInput?.focus();
+      }
+      isValid = false;
+    } else if (invoiceDateInput && invoiceDateInput.value && dueDateInput.value < invoiceDateInput.value) {
+      setFieldError(dueDateInput, dueDateError, 'Das Fälligkeitsdatum muss nach dem Rechnungsdatum liegen.');
+      if (isValid) {
+        dueDateInput?.focus();
+      }
+      isValid = false;
+    } else {
+      setFieldError(dueDateInput, dueDateError, '');
+    }
+
+    if (!taxRateInput || !taxRateInput.value) {
+      setFieldError(taxRateInput, taxRateError, 'Bitte wählen Sie einen Umsatzsteuersatz.');
+      if (isValid) {
+        taxRateInput?.focus();
+      }
+      isValid = false;
+    } else {
+      setFieldError(taxRateInput, taxRateError, '');
+    }
+
+    if (!isValid) {
+      return false;
+    }
+
+    persistInvoiceDetails();
+    updatePreview();
+    return true;
+  }
+
+  return true;
+}
+
+function persistInvoiceDetails() {
+  state.invoiceDetails = {
+    number: invoiceNumberInput?.value.trim() ?? '',
+    invoiceDate: invoiceDateInput?.value ?? '',
+    dueDate: dueDateInput?.value ?? '',
+    taxRate: getTaxRate(),
+    reference: referenceInput?.value.trim() ?? '',
+    paymentTerms: paymentTermsInput?.value.trim() ?? '',
+    notes: notesInput?.value.trim() ?? '',
+  };
+}
+
+function updatePreview() {
+  const selectedItems = state.lineItems.filter((item) =>
+    state.selectedEntryIds.includes(item.id)
+  );
+
+  const net = selectedItems.reduce((sum, item) => sum + item.hours * item.rate, 0);
+  const taxRate = getTaxRate();
+  const tax = net * (taxRate / 100);
+  const gross = net + tax;
+
+  if (previewMetaEl) {
+    const date = formatDate(state.invoiceDetails.invoiceDate);
+    previewMetaEl.textContent = `Rechnungsnummer ${state.invoiceDetails.number || '–'} · Datum ${date}`;
+  }
+  if (previewClientEl) {
+    previewClientEl.textContent = state.selectedClient || '–';
+  }
+  if (previewCaseEl) {
+    previewCaseEl.textContent =
+      state.selectedCase || state.lineItems[0]?.caseNumber || 'Alle Akten dieses Mandanten';
+  }
+  if (previewPeriodEl) {
+    const { start, end } = parsePeriodSelection();
+    previewPeriodEl.textContent = formatDateRange(start, end);
+  }
+  if (previewDueEl) {
+    previewDueEl.textContent = formatDate(state.invoiceDetails.dueDate);
+  }
+
+  if (previewItemsBody) {
+    previewItemsBody.innerHTML = '';
+    selectedItems.forEach((item) => {
+      const row = document.createElement('tr');
+      const descCell = document.createElement('td');
+      descCell.innerHTML = `
+        <div class="invoice-line__title">${item.description}</div>
+        <div class="invoice-line__meta">
+          ${item.caseTitle || 'Ohne Aktenbezug'}${
+            item.caseNumber ? ` · ${item.caseNumber}` : ''
+          }
+        </div>
+      `;
+      row.appendChild(descCell);
+
+      const hoursCell = document.createElement('td');
+      hoursCell.textContent = formatHours(item.hours);
+      row.appendChild(hoursCell);
+
+      const rateCell = document.createElement('td');
+      rateCell.textContent = formatCurrency(item.rate);
+      row.appendChild(rateCell);
+
+      const amountCell = document.createElement('td');
+      amountCell.textContent = formatCurrency(item.hours * item.rate);
+      row.appendChild(amountCell);
+
+      previewItemsBody.appendChild(row);
+    });
+  }
+
+  if (previewNetEl) {
+    previewNetEl.textContent = formatCurrency(net);
+  }
+  if (previewTaxEl) {
+    previewTaxEl.textContent = formatCurrency(tax);
+  }
+  if (previewGrossEl) {
+    previewGrossEl.textContent = formatCurrency(gross);
+  }
+  if (previewNotesEl) {
+    const noteParts = [state.invoiceDetails.paymentTerms, state.invoiceDetails.notes].filter(Boolean);
+    previewNotesEl.textContent = noteParts.join('\n\n');
+  }
+}
+
+function handleRateChange(event) {
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement)) {
+    return;
+  }
+  if (!target.classList.contains('invoice-line__rate')) {
+    return;
+  }
+
+  const entryId = target.dataset.entryId;
+  if (!entryId) {
+    return;
+  }
+
+  const value = Number.parseFloat(target.value);
+  const sanitized = Number.isFinite(value) && value >= 0 ? value : 0;
+  const lineItem = state.lineItems.find((item) => item.id === entryId);
+  if (!lineItem) {
+    return;
+  }
+
+  lineItem.rate = sanitized;
+  updateAmountDisplay(entryId);
+  updateTotals();
+}
+
+function handleSelectionChange(event) {
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement)) {
+    return;
+  }
+  if (target.type !== 'checkbox') {
+    return;
+  }
+
+  const entryId = target.dataset.entryId;
+  if (!entryId) {
+    return;
+  }
+
+  if (target.checked) {
+    if (!state.selectedEntryIds.includes(entryId)) {
+      state.selectedEntryIds.push(entryId);
+    }
+  } else {
+    state.selectedEntryIds = state.selectedEntryIds.filter((id) => id !== entryId);
+  }
+
+  updateTotals();
+}
+
+function populateClientOptions() {
+  if (!clientSelect) {
+    return;
+  }
+
+  const uniqueClients = new Map();
+  state.entries.forEach((entry) => {
+    if (!uniqueClients.has(entry.client)) {
+      uniqueClients.set(entry.client, []);
+    }
+    uniqueClients.get(entry.client).push(entry);
+  });
+
+  clientSelect.innerHTML = '<option value="" disabled selected>Mandant auswählen</option>';
+
+  uniqueClients.forEach((entries, client) => {
+    const option = document.createElement('option');
+    option.value = client;
+    option.textContent = client;
+    option.dataset.caseCount = String(entries.length);
+    clientSelect.appendChild(option);
+  });
+
+  if (uniqueClients.size === 1) {
+    const singleClient = uniqueClients.keys().next().value;
+    clientSelect.value = singleClient;
+  }
+}
+
+function populateCaseOptions(client) {
+  if (!caseSelect) {
+    return;
+  }
+
+  caseSelect.innerHTML = '<option value="">Alle Akten</option>';
+
+  const casesForClient = new Map();
+  state.entries
+    .filter((entry) => !client || entry.client === client)
+    .forEach((entry) => {
+      const label = entry.caseTitle || entry.caseNumber || 'Unbekannte Akte';
+      if (!casesForClient.has(entry.caseNumber)) {
+        casesForClient.set(entry.caseNumber, label);
+      }
+    });
+
+  casesForClient.forEach((label, caseNumber) => {
+    if (!caseNumber) {
+      return;
+    }
+    const option = document.createElement('option');
+    option.value = caseNumber;
+    option.textContent = `${caseNumber} – ${label}`;
+    caseSelect.appendChild(option);
+  });
+}
+
+function handleNext() {
+  if (!validateStep(state.activeStep)) {
+    return;
+  }
+  showStep(state.activeStep + 1);
+}
+
+function handlePrev() {
+  showStep(state.activeStep - 1);
+}
+
+function handleSubmit(event) {
+  event.preventDefault();
+  if (!validateStep(state.activeStep)) {
+    return;
+  }
+
+  updatePreview();
+  form?.setAttribute('hidden', '');
+  successMessage?.removeAttribute('hidden');
+  successMessage?.focus?.();
+}
+
+function resetWizard() {
+  form?.reset();
+  state.selectedEntryIds = [];
+  state.filteredEntries = [];
+  state.selectedClient = '';
+  state.selectedCase = '';
+  state.selectedPeriod = 'all';
+  state.invoiceDetails = {
+    number: '',
+    invoiceDate: '',
+    dueDate: '',
+    taxRate: 19,
+    reference: '',
+    paymentTerms: '',
+    notes: '',
+  };
+
+  populateClientOptions();
+  populateCaseOptions('');
+  applyDefaultInvoiceValues();
+  filterEntries();
+  form?.removeAttribute('hidden');
+  successMessage?.setAttribute('hidden', '');
+  showStep(1);
+}
+
+function applyDefaultInvoiceValues() {
+  const today = new Date();
+  const due = new Date(today);
+  due.setDate(today.getDate() + 14);
+
+  if (invoiceNumberInput) {
+    invoiceNumberInput.value = `INV-${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}${String(
+      today.getDate()
+    ).padStart(2, '0')}`;
+  }
+  if (invoiceDateInput) {
+    invoiceDateInput.value = today.toISOString().slice(0, 10);
+  }
+  if (dueDateInput) {
+    dueDateInput.value = due.toISOString().slice(0, 10);
+  }
+  if (taxRateInput) {
+    taxRateInput.value = '19';
+  }
+  if (paymentTermsInput) {
+    paymentTermsInput.value = 'Zahlbar innerhalb von 14 Tagen ohne Abzug auf das bekannte Kanzleikonto.';
+  }
+}
+
+function handleExport() {
+  const blob = new Blob(['PDF-Export ist ein Platzhalter in diesem Mock.'], {
+    type: 'application/pdf',
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${state.invoiceDetails.number || 'verilex-rechnung'}.pdf`;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function attachEventListeners() {
+  nextButton?.addEventListener('click', handleNext);
+  prevButton?.addEventListener('click', handlePrev);
+  form?.addEventListener('submit', handleSubmit);
+  resetButton?.addEventListener('click', resetWizard);
+  exportButton?.addEventListener('click', handleExport);
+
+  clientSelect?.addEventListener('change', () => {
+    setFieldError(clientSelect, clientErrorEl, '');
+    populateCaseOptions(clientSelect.value);
+    filterEntries();
+  });
+
+  periodSelect?.addEventListener('change', filterEntries);
+  caseSelect?.addEventListener('change', filterEntries);
+
+  itemsTableBody?.addEventListener('input', handleRateChange);
+  itemsTableBody?.addEventListener('change', handleSelectionChange);
+
+  taxRateInput?.addEventListener('change', () => {
+    getTaxRate();
+    updateTotals();
+    updatePreview();
+  });
+
+  invoiceNumberInput?.addEventListener('input', () =>
+    setFieldError(invoiceNumberInput, invoiceNumberError, '')
+  );
+  invoiceDateInput?.addEventListener('input', () =>
+    setFieldError(invoiceDateInput, invoiceDateError, '')
+  );
+  dueDateInput?.addEventListener('input', () =>
+    setFieldError(dueDateInput, dueDateError, '')
+  );
+  taxRateInput?.addEventListener('input', () =>
+    setFieldError(taxRateInput, taxRateError, '')
+  );
+}
+
+function initializeWizard() {
+  if (!form) {
+    return;
+  }
+
+  loadCaseDirectory();
+  state.entries = loadEntries();
+
+  populateClientOptions();
+  if (clientSelect?.value) {
+    populateCaseOptions(clientSelect.value);
+  } else {
+    populateCaseOptions('');
+  }
+
+  applyDefaultInvoiceValues();
+  filterEntries();
+  attachEventListeners();
+  showStep(1);
+}
+
+initializeWizard();

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
           <a class="btn btn-secondary" href="template-assistant.html">Vorlagen-Assistent</a>
           <a class="btn btn-secondary" href="time-tracking.html">Zeiterfassung</a>
           <a class="btn btn-secondary" href="performance-overview.html">Leistungsübersicht</a>
+          <a class="btn btn-secondary" href="invoice-wizard.html">Rechnungs-Wizard</a>
         </div>
       </section>
 

--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -1,0 +1,416 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Rechnungs-Wizard</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Rechnung erstellen</h1>
+      <p class="app-subtitle">
+        Führen Sie erfasste Leistungen zusammen, prüfen Sie die Angaben und exportieren Sie eine Vorschau als PDF-Mock.
+      </p>
+    </header>
+
+    <main class="app-main" aria-live="polite">
+      <nav class="wizard-breadcrumb" aria-label="Navigation">
+        <a class="wizard-breadcrumb__link" href="index.html">&larr; Zur Übersicht</a>
+      </nav>
+
+      <section class="app-card wizard-card" aria-labelledby="invoice-wizard-title">
+        <header class="wizard-card__header">
+          <h2 id="invoice-wizard-title">Rechnungs-Wizard</h2>
+          <p id="invoice-wizard-description" class="wizard-card__description">
+            Nutzen Sie die vorhandenen Leistungsdaten, um eine Rechnung mit wenigen Schritten aufzubauen. Alle Eingaben lassen sich vor dem Export anpassen.
+          </p>
+        </header>
+
+        <ol class="wizard-progress" role="list" aria-label="Fortschritt Rechnungs-Wizard">
+          <li class="wizard-progress__step" data-progress-step="1" role="listitem">
+            <span class="wizard-progress__label">Mandant & Zeitraum</span>
+          </li>
+          <li class="wizard-progress__step" data-progress-step="2" role="listitem">
+            <span class="wizard-progress__label">Leistungen prüfen</span>
+          </li>
+          <li class="wizard-progress__step" data-progress-step="3" role="listitem">
+            <span class="wizard-progress__label">Rechnungsdetails</span>
+          </li>
+          <li class="wizard-progress__step" data-progress-step="4" role="listitem">
+            <span class="wizard-progress__label">Vorschau & Export</span>
+          </li>
+        </ol>
+
+        <form id="invoice-form" class="wizard-form" novalidate aria-describedby="invoice-wizard-description">
+          <section class="wizard-step" data-step="1" aria-label="Mandant und Zeitraum wählen">
+            <fieldset class="wizard-fieldset">
+              <legend class="wizard-step__title" tabindex="-1">Schritt 1: Mandant und Zeitraum wählen</legend>
+              <p class="wizard-step__hint">
+                Wählen Sie den Mandanten sowie den Zeitraum, für den Leistungen abgerechnet werden sollen. Die Auswahl bestimmt, welche Tätigkeiten im nächsten Schritt vorgeschlagen werden.
+              </p>
+
+              <div class="form-grid">
+                <div class="form-field">
+                  <label for="invoice-client">Mandant *</label>
+                  <select id="invoice-client" name="client" required aria-describedby="invoice-client-error">
+                    <option value="" disabled selected>Mandant auswählen</option>
+                  </select>
+                  <p id="invoice-client-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="invoice-period">Leistungszeitraum</label>
+                  <select id="invoice-period" name="period" aria-describedby="invoice-period-hint">
+                    <option value="all" selected>Alle erfassten Leistungen</option>
+                    <option value="30">Letzte 30 Tage</option>
+                    <option value="90">Letzte 90 Tage</option>
+                    <option value="365">Letzte 365 Tage</option>
+                  </select>
+                  <p id="invoice-period-hint" class="form-field__hint">
+                    Der Zeitraum filtert Leistungen anhand des Enddatums.
+                  </p>
+                </div>
+
+                <div class="form-field">
+                  <label for="invoice-case-filter">Akte (optional)</label>
+                  <select id="invoice-case-filter" name="case" aria-describedby="invoice-case-hint">
+                    <option value="">Alle Akten</option>
+                  </select>
+                  <p id="invoice-case-hint" class="form-field__hint">
+                    Eingrenzung auf eine konkrete Akte, sofern mehrere vorhanden sind.
+                  </p>
+                </div>
+              </div>
+
+              <div id="invoice-filter-summary" class="invoice-summary" role="status" aria-live="polite"></div>
+              <p id="invoice-step1-error" class="field-error" role="status" aria-live="polite"></p>
+            </fieldset>
+          </section>
+
+          <section class="wizard-step" data-step="2" aria-label="Leistungen prüfen" hidden>
+            <fieldset class="wizard-fieldset">
+              <legend class="wizard-step__title" tabindex="-1">Schritt 2: Leistungen prüfen</legend>
+              <p class="wizard-step__hint">
+                Prüfen Sie die vorausgewählten Leistungen. Sie können einzelne Positionen abwählen oder Stundensätze anpassen.
+              </p>
+
+              <div class="invoice-table-wrapper" role="region" aria-labelledby="invoice-table-heading">
+                <h3 id="invoice-table-heading" class="visually-hidden">Leistungspositionen</h3>
+                <table class="invoice-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Auswahl</th>
+                      <th scope="col">Leistung</th>
+                      <th scope="col">Dauer</th>
+                      <th scope="col">Stundensatz (€)</th>
+                      <th scope="col">Betrag (€)</th>
+                    </tr>
+                  </thead>
+                  <tbody id="invoice-line-items"></tbody>
+                </table>
+              </div>
+
+              <p id="invoice-items-empty" class="invoice-empty-state" hidden>
+                Für die aktuelle Auswahl stehen keine Leistungen zur Verfügung. Bitte passen Sie Mandant, Zeitraum oder Akte an.
+              </p>
+
+              <p id="invoice-items-error" class="field-error" role="status" aria-live="polite"></p>
+
+              <dl class="invoice-totals" aria-label="Summenübersicht">
+                <div class="invoice-totals__item">
+                  <dt>Ausgewählte Stunden</dt>
+                  <dd id="invoice-total-hours">0,00 h</dd>
+                </div>
+                <div class="invoice-totals__item">
+                  <dt>Zwischensumme (netto)</dt>
+                  <dd id="invoice-total-net">0,00 €</dd>
+                </div>
+                <div class="invoice-totals__item">
+                  <dt>Umsatzsteuer</dt>
+                  <dd id="invoice-total-tax">0,00 €</dd>
+                </div>
+                <div class="invoice-totals__item invoice-totals__item--highlight">
+                  <dt>Gesamtsumme (brutto)</dt>
+                  <dd id="invoice-total-gross">0,00 €</dd>
+                </div>
+              </dl>
+            </fieldset>
+          </section>
+
+          <section class="wizard-step" data-step="3" aria-label="Rechnungsdetails" hidden>
+            <fieldset class="wizard-fieldset">
+              <legend class="wizard-step__title" tabindex="-1">Schritt 3: Rechnungsdetails</legend>
+              <p class="wizard-step__hint">
+                Ergänzen Sie die Pflichtangaben zur Rechnung. Die Informationen fließen in die Vorschau ein.
+              </p>
+
+              <div class="form-grid">
+                <div class="form-field">
+                  <label for="invoice-number">Rechnungsnummer *</label>
+                  <input
+                    id="invoice-number"
+                    name="invoiceNumber"
+                    type="text"
+                    inputmode="text"
+                    autocomplete="off"
+                    required
+                    maxlength="32"
+                    aria-describedby="invoice-number-error"
+                  />
+                  <p id="invoice-number-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="invoice-date">Rechnungsdatum *</label>
+                  <input
+                    id="invoice-date"
+                    name="invoiceDate"
+                    type="date"
+                    required
+                    aria-describedby="invoice-date-error"
+                  />
+                  <p id="invoice-date-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="invoice-due-date">Fällig bis *</label>
+                  <input
+                    id="invoice-due-date"
+                    name="dueDate"
+                    type="date"
+                    required
+                    aria-describedby="invoice-due-date-error"
+                  />
+                  <p id="invoice-due-date-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="invoice-tax-rate">Umsatzsteuer *</label>
+                  <select id="invoice-tax-rate" name="taxRate" required aria-describedby="invoice-tax-rate-error">
+                    <option value="19" selected>19 %</option>
+                    <option value="7">7 %</option>
+                    <option value="0">0 %</option>
+                  </select>
+                  <p id="invoice-tax-rate-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+              </div>
+
+              <div class="form-grid">
+                <div class="form-field">
+                  <label for="invoice-reference">Referenz / Aktenzeichen</label>
+                  <input id="invoice-reference" name="reference" type="text" maxlength="80" autocomplete="off" />
+                </div>
+
+                <div class="form-field">
+                  <label for="invoice-payment-terms">Zahlungshinweis</label>
+                  <textarea
+                    id="invoice-payment-terms"
+                    name="paymentTerms"
+                    rows="3"
+                    maxlength="240"
+                    aria-describedby="invoice-payment-terms-hint"
+                  ></textarea>
+                  <p id="invoice-payment-terms-hint" class="form-field__hint">
+                    Beispiel: „Zahlbar innerhalb von 14 Tagen ohne Abzug auf das bekannte Kanzleikonto.“
+                  </p>
+                </div>
+
+                <div class="form-field form-field--wide">
+                  <label for="invoice-notes">Anmerkungen (optional)</label>
+                  <textarea id="invoice-notes" name="notes" rows="3" maxlength="360"></textarea>
+                </div>
+              </div>
+            </fieldset>
+          </section>
+
+          <section class="wizard-step" data-step="4" aria-label="Vorschau und Export" hidden>
+            <fieldset class="wizard-fieldset">
+              <legend class="wizard-step__title" tabindex="-1">Schritt 4: Vorschau &amp; Export</legend>
+              <p class="wizard-step__hint">
+                Prüfen Sie die Zusammenfassung. Über den PDF-Export erhalten Sie eine Dummy-Datei als Platzhalter.
+              </p>
+
+              <article class="invoice-preview" aria-labelledby="invoice-preview-heading">
+                <header>
+                  <h3 id="invoice-preview-heading">Rechnungsvorschau</h3>
+                  <p id="invoice-preview-meta" class="invoice-preview__meta"></p>
+                </header>
+
+                <dl class="summary-grid" aria-label="Rechnungsdetails">
+                  <div>
+                    <dt>Mandant</dt>
+                    <dd id="invoice-preview-client">–</dd>
+                  </div>
+                  <div>
+                    <dt>Akte</dt>
+                    <dd id="invoice-preview-case">–</dd>
+                  </div>
+                  <div>
+                    <dt>Zeitraum</dt>
+                    <dd id="invoice-preview-period">–</dd>
+                  </div>
+                  <div>
+                    <dt>Fällig bis</dt>
+                    <dd id="invoice-preview-due">–</dd>
+                  </div>
+                </dl>
+
+                <div class="invoice-table-wrapper">
+                  <table class="invoice-table invoice-table--preview">
+                    <thead>
+                      <tr>
+                        <th scope="col">Leistung</th>
+                        <th scope="col">Dauer</th>
+                        <th scope="col">Satz</th>
+                        <th scope="col">Betrag</th>
+                      </tr>
+                    </thead>
+                    <tbody id="invoice-preview-items"></tbody>
+                  </table>
+                </div>
+
+                <dl class="invoice-totals invoice-totals--preview" aria-label="Rechnungssummen">
+                  <div class="invoice-totals__item">
+                    <dt>Zwischensumme</dt>
+                    <dd id="invoice-preview-net">0,00 €</dd>
+                  </div>
+                  <div class="invoice-totals__item">
+                    <dt>Umsatzsteuer</dt>
+                    <dd id="invoice-preview-tax">0,00 €</dd>
+                  </div>
+                  <div class="invoice-totals__item invoice-totals__item--highlight">
+                    <dt>Gesamtbetrag</dt>
+                    <dd id="invoice-preview-gross">0,00 €</dd>
+                  </div>
+                </dl>
+
+                <p id="invoice-preview-notes" class="invoice-preview__notes"></p>
+              </article>
+
+              <div class="invoice-preview__actions">
+                <button type="button" class="btn btn-secondary" id="invoice-export">
+                  PDF-Export (Mock)
+                </button>
+              </div>
+            </fieldset>
+          </section>
+
+          <div class="wizard-navigation" role="group" aria-label="Wizard-Steuerung">
+            <button type="button" class="btn btn-secondary" id="invoice-prev" data-action="prev" disabled>
+              Zurück
+            </button>
+            <button type="button" class="btn btn-primary" id="invoice-next" data-action="next">
+              Weiter
+            </button>
+            <button type="submit" class="btn btn-success" id="invoice-submit" data-action="submit" hidden>
+              Rechnung abschließen
+            </button>
+          </div>
+        </form>
+
+        <div id="invoice-success" class="wizard-success" role="alert" hidden tabindex="-1">
+          <h3>Rechnungsvorschau erstellt</h3>
+          <p>
+            Die Rechnung wurde vorbereitet. Nutzen Sie den PDF-Export, um die Dummy-Datei herunterzuladen oder passen Sie die Angaben erneut an.
+          </p>
+          <button type="button" class="btn" id="invoice-reset">Neue Rechnung erstellen</button>
+        </div>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details" hidden>
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">Seite neu laden</button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">Schließen</button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="application/json" id="invoice-entry-data">
+      [
+        {
+          "id": "demo-entry-1",
+          "activity": "Akteneinsicht und Mandantenbrief",
+          "caseNumber": "V-2024-001",
+          "caseTitle": "Vertragsprüfung Müller GmbH",
+          "client": "Müller GmbH",
+          "durationMs": 7200000,
+          "endedAt": "2025-10-15T14:45:00.000Z",
+          "notes": "Zusammenfassung der Vertragsklauseln",
+          "rate": 195
+        },
+        {
+          "id": "demo-entry-2",
+          "activity": "Telefonkonferenz mit Gegenpartei",
+          "caseNumber": "V-2024-001",
+          "caseTitle": "Vertragsprüfung Müller GmbH",
+          "client": "Müller GmbH",
+          "durationMs": 3600000,
+          "endedAt": "2025-10-22T09:30:00.000Z",
+          "notes": "Abstimmung zu Anpassungen",
+          "rate": 205
+        },
+        {
+          "id": "demo-entry-3",
+          "activity": "Schriftsatz Entwurf",
+          "caseNumber": "A-2024-017",
+          "caseTitle": "Arbeitsrechtliche Beratung Schmidt",
+          "client": "Eva Schmidt",
+          "durationMs": 5400000,
+          "endedAt": "2025-10-28T16:10:00.000Z",
+          "notes": "Kündigungsschutzschrift",
+          "rate": 180
+        },
+        {
+          "id": "demo-entry-4",
+          "activity": "Besprechung im Mandat",
+          "caseNumber": "A-2024-017",
+          "caseTitle": "Arbeitsrechtliche Beratung Schmidt",
+          "client": "Eva Schmidt",
+          "durationMs": 4500000,
+          "endedAt": "2025-10-30T11:00:00.000Z",
+          "notes": "Vorbereitung Gütetermin",
+          "rate": 180
+        }
+      ]
+    </script>
+
+    <script type="application/json" id="invoice-case-directory">
+      [
+        { "caseNumber": "V-2024-001", "title": "Vertragsprüfung Müller GmbH", "client": "Müller GmbH", "defaultRate": 195 },
+        { "caseNumber": "A-2024-017", "title": "Arbeitsrechtliche Beratung Schmidt", "client": "Eva Schmidt", "defaultRate": 180 },
+        { "caseNumber": "I-2024-004", "title": "Investitionsprüfung GreenTech", "client": "GreenTech Holding", "defaultRate": 210 },
+        { "caseNumber": "S-2024-032", "title": "Steuerprüfung Contoso AG", "client": "Contoso AG", "defaultRate": 220 }
+      ]
+    </script>
+
+    <script src="assets/js/app.js" type="module"></script>
+    <script src="assets/js/invoice-wizard.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a multi-step invoice wizard page that compiles time entries into line items and exports a mock PDF
- introduce supporting JavaScript logic to load stored time entries, calculate totals, and render previews
- extend shared styles and navigation to surface the new billing flow and document task completion

## Testing
- not run (HTML/CSS/JS changes only)

------
https://chatgpt.com/codex/tasks/task_e_690b0d541c308320b9e39d653de31720