### PR TITLE
Add mock overview for open receivables

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -49,8 +49,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 11. **Rechnungs-Wizard** – Baue einen Wizard zur Rechnungserstellung auf Basis erfasster Leistungen. Zeige Vorschau und PDF-Export (Dummy).
     Status: ✅ erledigt – 2025-11-05
 
-12. **Offene-Posten-Übersicht (Mock)** – Zeige Rechnungen mit Status „bezahlt“, „überfällig“, „offen“. Keine echte Datenbank nötig.  
-    Status: ⬜
+12. **Offene-Posten-Übersicht (Mock)** – Zeige Rechnungen mit Status „bezahlt“, „überfällig“, „offen“. Keine echte Datenbank nötig.
+    Status: ✅ erledigt – 2025-11-05
 
 13. **E-Mail-Integration (Mock)** – Erstelle eine Demo-Inbox mit Nachrichtenliste und Detailansicht. Alle E-Mails sind Dummy-Einträge aus JSON.  
     Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2406,3 +2406,238 @@ body {
     justify-content: center;
   }
 }
+
+.receivables-main {
+  width: min(1100px, 100%);
+  align-items: stretch;
+}
+
+.receivables-board {
+  width: 100%;
+  background: #fff;
+  border-radius: 18px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(31, 60, 136, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 4vw, 2.25rem);
+}
+
+.receivables-board__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(1rem, 3vw, 2rem);
+}
+
+.receivables-board__description {
+  margin: 0.35rem 0 0;
+  max-width: 60ch;
+  color: #4b5563;
+}
+
+.receivables-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: clamp(0.75rem, 3vw, 1.25rem);
+  margin: 0;
+  padding: 0;
+}
+
+.receivables-summary__item {
+  border-radius: 14px;
+  padding: 0.85rem 1.15rem;
+  display: grid;
+  gap: 0.45rem;
+  border: 1px solid rgba(47, 116, 192, 0.12);
+  background: rgba(47, 116, 192, 0.06);
+}
+
+.receivables-summary__item--overdue {
+  border-color: rgba(220, 38, 38, 0.35);
+  background: rgba(220, 38, 38, 0.14);
+}
+
+.receivables-summary__item--paid {
+  border-color: rgba(16, 185, 129, 0.3);
+  background: rgba(16, 185, 129, 0.14);
+}
+
+.receivables-summary__item dt {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4b5563;
+}
+
+.receivables-summary__item dd {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.receivables-summary__count {
+  font-size: 1.3rem;
+}
+
+.receivables-summary__amount {
+  font-size: 1.05rem;
+  color: #1f2933;
+}
+
+.receivables-highlight {
+  margin: 0;
+  padding: 0.85rem 1.15rem;
+  border-left: 4px solid #2f74c0;
+  background: rgba(47, 116, 192, 0.08);
+  border-radius: 12px;
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.receivables-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.85rem clamp(0.85rem, 3vw, 1.5rem);
+  padding: clamp(1rem, 3vw, 1.5rem);
+  border-radius: 16px;
+  border: 1px solid rgba(47, 116, 192, 0.12);
+  background: rgba(47, 116, 192, 0.06);
+}
+
+.receivables-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.receivables-filter__label {
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #4b5563;
+}
+
+.receivables-filter--checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.receivables-filter--checkbox label {
+  font-weight: 600;
+  color: #1f2933;
+}
+
+.receivables-table {
+  width: 100%;
+  min-width: 720px;
+  border-collapse: collapse;
+}
+
+.receivables-table thead {
+  background: rgba(47, 116, 192, 0.08);
+}
+
+.receivables-table th,
+.receivables-table td {
+  text-align: left;
+  padding: 0.75rem 0.95rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  vertical-align: top;
+}
+
+.receivables-table th {
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6b7280;
+}
+
+.receivables-table__primary {
+  display: block;
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.receivables-table__secondary {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.receivables-table__cell--amount {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.receivables-table__amount {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #1f2933;
+}
+
+.receivables-table__cell--status {
+  min-width: 180px;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  padding: 0.3rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.status-badge--open {
+  background: rgba(47, 116, 192, 0.15);
+  border-color: rgba(47, 116, 192, 0.3);
+  color: #1f3c88;
+}
+
+.status-badge--overdue {
+  background: rgba(220, 38, 38, 0.18);
+  border-color: rgba(220, 38, 38, 0.35);
+  color: #b91c1c;
+}
+
+.status-badge--paid {
+  background: rgba(16, 185, 129, 0.18);
+  border-color: rgba(16, 185, 129, 0.35);
+  color: #047857;
+}
+
+.receivables-table-summary {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2933;
+}
+
+.receivables-empty-state {
+  margin: 0;
+  padding: 1rem 1.5rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.05);
+  color: #4b5563;
+  font-weight: 500;
+}
+
+@media (max-width: 720px) {
+  .receivables-table {
+    min-width: 100%;
+  }
+
+  .receivables-table__cell--status {
+    min-width: unset;
+  }
+}

--- a/assets/js/open-items.js
+++ b/assets/js/open-items.js
@@ -1,0 +1,376 @@
+const dataElement = document.getElementById('receivables-data');
+if (!dataElement) {
+  console.warn('Receivables data element not found.');
+}
+
+const currencyFormatter = new Intl.NumberFormat('de-DE', {
+  style: 'currency',
+  currency: 'EUR',
+});
+
+const numberFormatter = new Intl.NumberFormat('de-DE');
+const dateFormatter = new Intl.DateTimeFormat('de-DE', {
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric',
+});
+
+const relativeFormatter = new Intl.RelativeTimeFormat('de', {
+  numeric: 'auto',
+});
+
+const statusLabels = {
+  open: 'Offen',
+  overdue: 'Überfällig',
+  paid: 'Bezahlt',
+};
+
+function parseDate(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function normalizeReceivable(entry) {
+  const normalizedStatus = String(entry.status ?? 'open').toLowerCase();
+  const allowedStatuses = new Set(['open', 'overdue', 'paid']);
+
+  return {
+    invoiceNumber: String(entry.invoiceNumber ?? '').trim() || '–',
+    caseNumber: String(entry.caseNumber ?? '').trim(),
+    matter: String(entry.matter ?? '').trim(),
+    client: String(entry.client ?? '').trim() || 'Unbekannter Mandant',
+    issueDate: parseDate(entry.issueDate),
+    dueDate: parseDate(entry.dueDate),
+    paidDate: parseDate(entry.paidDate),
+    amount: typeof entry.amount === 'number' ? entry.amount : Number(entry.amount) || 0,
+    status: allowedStatuses.has(normalizedStatus) ? normalizedStatus : 'open',
+    note: String(entry.note ?? '').trim(),
+  };
+}
+
+function loadReceivables() {
+  if (!dataElement) {
+    return [];
+  }
+
+  try {
+    const raw = dataElement.textContent ?? '[]';
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.map((entry) => normalizeReceivable(entry));
+  } catch (error) {
+    console.error('Die Rechnungsdaten konnten nicht geladen werden.', error);
+    window.dispatchEvent(
+      new CustomEvent('verilex:error', {
+        detail: {
+          title: 'Fehler beim Laden der Rechnungen',
+          message: 'Die Offene-Posten-Daten konnten nicht interpretiert werden.',
+          details: error,
+        },
+      })
+    );
+    return [];
+  }
+}
+
+const receivables = loadReceivables();
+
+const tableBody = document.getElementById('receivables-table-body');
+const emptyState = document.getElementById('receivables-empty-state');
+const tableSummary = document.getElementById('receivables-table-summary');
+const outstandingTotal = document.getElementById('receivables-outstanding-total');
+const searchInput = document.getElementById('receivables-search');
+const statusFilter = document.getElementById('receivables-status-filter');
+const outstandingOnlyToggle = document.getElementById('receivables-outstanding-only');
+
+const summaryElements = {
+  open: {
+    count: document.getElementById('receivables-summary-open-count'),
+    amount: document.getElementById('receivables-summary-open-amount'),
+  },
+  overdue: {
+    count: document.getElementById('receivables-summary-overdue-count'),
+    amount: document.getElementById('receivables-summary-overdue-amount'),
+  },
+  paid: {
+    count: document.getElementById('receivables-summary-paid-count'),
+    amount: document.getElementById('receivables-summary-paid-amount'),
+  },
+};
+
+const filters = {
+  query: '',
+  status: 'all',
+  outstandingOnly: false,
+};
+
+function formatDate(date) {
+  return date ? dateFormatter.format(date) : '–';
+}
+
+function formatAmount(amount) {
+  return currencyFormatter.format(amount ?? 0);
+}
+
+function describeDueDate(dueDate) {
+  if (!dueDate) {
+    return 'Kein Fälligkeitsdatum hinterlegt';
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(dueDate);
+  due.setHours(0, 0, 0, 0);
+
+  const diffDays = Math.round((due.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) {
+    return 'Heute fällig';
+  }
+
+  if (diffDays < 0) {
+    const days = Math.abs(diffDays);
+    return days === 1 ? 'Überfällig seit 1 Tag' : `Überfällig seit ${days} Tagen`;
+  }
+
+  return `Fällig ${relativeFormatter.format(diffDays, 'day')}`;
+}
+
+function matchesSearch(entry, query) {
+  if (!query) {
+    return true;
+  }
+
+  const haystack = [
+    entry.invoiceNumber,
+    entry.client,
+    entry.caseNumber,
+    entry.matter,
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  return haystack.includes(query.toLowerCase());
+}
+
+function sortReceivables(list) {
+  const statusPriority = {
+    overdue: 0,
+    open: 1,
+    paid: 2,
+  };
+
+  return [...list].sort((a, b) => {
+    const statusDiff = (statusPriority[a.status] ?? 99) - (statusPriority[b.status] ?? 99);
+    if (statusDiff !== 0) {
+      return statusDiff;
+    }
+
+    const aDue = a.dueDate ? a.dueDate.getTime() : Number.POSITIVE_INFINITY;
+    const bDue = b.dueDate ? b.dueDate.getTime() : Number.POSITIVE_INFINITY;
+    if (aDue !== bDue) {
+      return aDue - bDue;
+    }
+
+    return a.invoiceNumber.localeCompare(b.invoiceNumber, 'de');
+  });
+}
+
+function updateSummary(list) {
+  const aggregates = {
+    open: { count: 0, amount: 0 },
+    overdue: { count: 0, amount: 0 },
+    paid: { count: 0, amount: 0 },
+  };
+
+  list.forEach((entry) => {
+    const bucket = aggregates[entry.status];
+    if (bucket) {
+      bucket.count += 1;
+      bucket.amount += entry.amount;
+    }
+  });
+
+  (Object.keys(summaryElements)).forEach((key) => {
+    const elements = summaryElements[key];
+    const data = aggregates[key] ?? { count: 0, amount: 0 };
+    if (elements?.count) {
+      elements.count.textContent = numberFormatter.format(data.count);
+    }
+    if (elements?.amount) {
+      elements.amount.textContent = formatAmount(data.amount);
+    }
+  });
+
+  if (outstandingTotal) {
+    const openAmount = aggregates.open.amount + aggregates.overdue.amount;
+    outstandingTotal.textContent = `Summe offener und überfälliger Posten: ${formatAmount(openAmount)}`;
+  }
+}
+
+function renderTable(list) {
+  if (!tableBody) {
+    return;
+  }
+
+  tableBody.innerHTML = '';
+
+  const fragment = document.createDocumentFragment();
+
+  list.forEach((entry) => {
+    const row = document.createElement('tr');
+
+    const invoiceCell = document.createElement('td');
+    invoiceCell.className = 'receivables-table__cell';
+    const invoicePrimary = document.createElement('span');
+    invoicePrimary.className = 'receivables-table__primary';
+    invoicePrimary.textContent = entry.invoiceNumber;
+    invoiceCell.append(invoicePrimary);
+
+    const invoiceSecondary = document.createElement('span');
+    invoiceSecondary.className = 'receivables-table__secondary';
+    invoiceSecondary.textContent = entry.issueDate
+      ? `Erstellt am ${formatDate(entry.issueDate)}`
+      : 'Erstellungsdatum unbekannt';
+    invoiceCell.append(invoiceSecondary);
+
+    const clientCell = document.createElement('td');
+    clientCell.className = 'receivables-table__cell';
+    const clientPrimary = document.createElement('span');
+    clientPrimary.className = 'receivables-table__primary';
+    clientPrimary.textContent = entry.client;
+    clientCell.append(clientPrimary);
+
+    const clientSecondary = document.createElement('span');
+    clientSecondary.className = 'receivables-table__secondary';
+    const matterParts = [];
+    if (entry.caseNumber) {
+      matterParts.push(`Akte ${entry.caseNumber}`);
+    }
+    if (entry.matter) {
+      matterParts.push(entry.matter);
+    }
+    clientSecondary.textContent = matterParts.join(' · ') || 'Kein Aktenbezug hinterlegt';
+    clientCell.append(clientSecondary);
+
+    const dueCell = document.createElement('td');
+    dueCell.className = 'receivables-table__cell';
+    const duePrimary = document.createElement('span');
+    duePrimary.className = 'receivables-table__primary';
+    duePrimary.textContent = formatDate(entry.dueDate);
+    dueCell.append(duePrimary);
+
+    const dueSecondary = document.createElement('span');
+    dueSecondary.className = 'receivables-table__secondary';
+    dueSecondary.textContent = describeDueDate(entry.dueDate);
+    dueCell.append(dueSecondary);
+
+    const amountCell = document.createElement('td');
+    amountCell.className = 'receivables-table__cell receivables-table__cell--amount';
+    const amountPrimary = document.createElement('span');
+    amountPrimary.className = 'receivables-table__amount';
+    amountPrimary.textContent = formatAmount(entry.amount);
+    amountCell.append(amountPrimary);
+
+    const statusCell = document.createElement('td');
+    statusCell.className = 'receivables-table__cell receivables-table__cell--status';
+    const statusBadge = document.createElement('span');
+    statusBadge.className = `status-badge status-badge--${entry.status}`;
+    statusBadge.textContent = statusLabels[entry.status] ?? entry.status;
+    statusCell.append(statusBadge);
+
+    if (entry.status === 'paid' && entry.paidDate) {
+      const paidInfo = document.createElement('span');
+      paidInfo.className = 'receivables-table__secondary';
+      paidInfo.textContent = `Bezahlt am ${formatDate(entry.paidDate)}`;
+      statusCell.append(paidInfo);
+    } else if (entry.status !== 'paid' && entry.note) {
+      const noteInfo = document.createElement('span');
+      noteInfo.className = 'receivables-table__secondary';
+      noteInfo.textContent = entry.note;
+      statusCell.append(noteInfo);
+    } else if (entry.status !== 'paid') {
+      const dueInfo = document.createElement('span');
+      dueInfo.className = 'receivables-table__secondary';
+      dueInfo.textContent = entry.note || 'Noch keine Rückmeldung erfasst';
+      statusCell.append(dueInfo);
+    }
+
+    row.append(invoiceCell, clientCell, dueCell, amountCell, statusCell);
+    fragment.append(row);
+  });
+
+  tableBody.append(fragment);
+}
+
+function updateEmptyState(count) {
+  if (!emptyState) {
+    return;
+  }
+
+  if (count === 0) {
+    emptyState.removeAttribute('hidden');
+  } else {
+    emptyState.setAttribute('hidden', '');
+  }
+}
+
+function updateTableSummary(count) {
+  if (!tableSummary) {
+    return;
+  }
+
+  const formattedCount = numberFormatter.format(count);
+  tableSummary.textContent =
+    count === 1 ? '1 Rechnung gefunden.' : `${formattedCount} Rechnungen gefunden.`;
+}
+
+function applyFilters() {
+  const filtered = receivables.filter((entry) => {
+    if (!matchesSearch(entry, filters.query)) {
+      return false;
+    }
+
+    if (filters.status !== 'all' && entry.status !== filters.status) {
+      return false;
+    }
+
+    if (filters.outstandingOnly && entry.status === 'paid') {
+      return false;
+    }
+
+    return true;
+  });
+
+  const sorted = sortReceivables(filtered);
+  renderTable(sorted);
+  updateSummary(sorted);
+  updateTableSummary(sorted.length);
+  updateEmptyState(sorted.length);
+}
+
+applyFilters();
+
+if (searchInput) {
+  searchInput.addEventListener('input', (event) => {
+    filters.query = event.target.value.trim();
+    applyFilters();
+  });
+}
+
+if (statusFilter) {
+  statusFilter.addEventListener('change', (event) => {
+    filters.status = event.target.value;
+    applyFilters();
+  });
+}
+
+if (outstandingOnlyToggle) {
+  outstandingOnlyToggle.addEventListener('change', (event) => {
+    filters.outstandingOnly = event.target.checked;
+    applyFilters();
+  });
+}

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
           <a class="btn btn-secondary" href="time-tracking.html">Zeiterfassung</a>
           <a class="btn btn-secondary" href="performance-overview.html">Leistungsübersicht</a>
           <a class="btn btn-secondary" href="invoice-wizard.html">Rechnungs-Wizard</a>
+          <a class="btn btn-secondary" href="open-items.html">Offene Posten</a>
         </div>
       </section>
 

--- a/open-items.html
+++ b/open-items.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Offene-Posten-Übersicht</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Offene-Posten-Übersicht</h1>
+      <p class="app-subtitle">
+        Behalten Sie unbezahlte Rechnungen, offene Beträge und bereits beglichene Vorgänge transparent im Blick.
+      </p>
+      <div class="welcome-actions">
+        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
+        <a class="btn btn-secondary" href="performance-overview.html">Leistungsübersicht</a>
+        <a class="btn btn-secondary" href="invoice-wizard.html">Rechnungs-Wizard</a>
+      </div>
+    </header>
+
+    <main class="app-main receivables-main" aria-live="polite">
+      <section class="receivables-board" aria-labelledby="receivables-title">
+        <header class="receivables-board__header">
+          <div>
+            <h2 id="receivables-title">Statusüberblick Ihrer Forderungen</h2>
+            <p class="receivables-board__description">
+              Die nachfolgende Liste basiert auf Demo-Daten und zeigt, welche Rechnungen offen, überfällig oder bereits bezahlt
+              sind. Nutzen Sie die Filter, um sich auf relevante Fälle zu konzentrieren.
+            </p>
+          </div>
+          <dl class="receivables-summary" aria-label="Summen nach Status">
+            <div class="receivables-summary__item receivables-summary__item--open">
+              <dt>Offen</dt>
+              <dd>
+                <span id="receivables-summary-open-count" class="receivables-summary__count">0</span>
+                <span class="receivables-summary__separator" aria-hidden="true">·</span>
+                <span id="receivables-summary-open-amount" class="receivables-summary__amount">0,00&nbsp;€</span>
+              </dd>
+            </div>
+            <div class="receivables-summary__item receivables-summary__item--overdue">
+              <dt>Überfällig</dt>
+              <dd>
+                <span id="receivables-summary-overdue-count" class="receivables-summary__count">0</span>
+                <span class="receivables-summary__separator" aria-hidden="true">·</span>
+                <span id="receivables-summary-overdue-amount" class="receivables-summary__amount">0,00&nbsp;€</span>
+              </dd>
+            </div>
+            <div class="receivables-summary__item receivables-summary__item--paid">
+              <dt>Bezahlt</dt>
+              <dd>
+                <span id="receivables-summary-paid-count" class="receivables-summary__count">0</span>
+                <span class="receivables-summary__separator" aria-hidden="true">·</span>
+                <span id="receivables-summary-paid-amount" class="receivables-summary__amount">0,00&nbsp;€</span>
+              </dd>
+            </div>
+          </dl>
+        </header>
+
+        <p id="receivables-outstanding-total" class="receivables-highlight" role="status">
+          Summe offener und überfälliger Posten: 0,00&nbsp;€
+        </p>
+
+        <form class="receivables-filters" aria-label="Rechnungen filtern" novalidate>
+          <div class="receivables-filter">
+            <label class="receivables-filter__label" for="receivables-search">Schnellsuche</label>
+            <input
+              type="search"
+              id="receivables-search"
+              name="search"
+              placeholder="Nach Rechnungsnummer, Mandant oder Akte suchen"
+              autocomplete="off"
+              spellcheck="false"
+              aria-describedby="receivables-table-summary"
+            />
+          </div>
+          <div class="receivables-filter">
+            <label class="receivables-filter__label" for="receivables-status-filter">Status</label>
+            <select id="receivables-status-filter" name="status">
+              <option value="all">Alle Status</option>
+              <option value="open">Offen</option>
+              <option value="overdue">Überfällig</option>
+              <option value="paid">Bezahlt</option>
+            </select>
+          </div>
+          <div class="receivables-filter receivables-filter--checkbox">
+            <input type="checkbox" id="receivables-outstanding-only" name="outstandingOnly" />
+            <label for="receivables-outstanding-only">Nur offene &amp; überfällige anzeigen</label>
+          </div>
+        </form>
+
+        <p id="receivables-table-summary" class="receivables-table-summary" role="status">
+          0 Rechnungen gefunden.
+        </p>
+
+        <div class="table-wrapper" role="region" aria-labelledby="receivables-title" aria-live="polite">
+          <table class="receivables-table">
+            <thead>
+              <tr>
+                <th scope="col">Rechnung</th>
+                <th scope="col">Mandant &amp; Akte</th>
+                <th scope="col">Fälligkeit</th>
+                <th scope="col">Betrag</th>
+                <th scope="col">Status</th>
+              </tr>
+            </thead>
+            <tbody id="receivables-table-body"></tbody>
+          </table>
+        </div>
+        <p id="receivables-empty-state" class="receivables-empty-state" hidden>
+          Für die aktuelle Filterauswahl sind keine Rechnungen vorhanden.
+        </p>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details">
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">Seite neu laden</button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">Schließen</button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="application/json" id="receivables-data">
+      [
+        {
+          "invoiceNumber": "RE-2025-021",
+          "caseNumber": "V-2024-001",
+          "matter": "Vertragsprüfung Müller GmbH",
+          "client": "Müller GmbH",
+          "issueDate": "2025-09-28",
+          "dueDate": "2025-10-28",
+          "amount": 2980.0,
+          "status": "overdue",
+          "note": "Mahnung vom 30.10. versendet"
+        },
+        {
+          "invoiceNumber": "RE-2025-034",
+          "caseNumber": "A-2024-017",
+          "matter": "Arbeitsrechtliche Beratung Schmidt",
+          "client": "Eva Schmidt",
+          "issueDate": "2025-10-12",
+          "dueDate": "2025-11-11",
+          "amount": 1650.5,
+          "status": "open",
+          "note": "Rückfrage des Mandanten offen"
+        },
+        {
+          "invoiceNumber": "RE-2025-037",
+          "caseNumber": "I-2024-004",
+          "matter": "Investitionsprüfung GreenTech",
+          "client": "GreenTech Holding",
+          "issueDate": "2025-09-20",
+          "dueDate": "2025-10-05",
+          "amount": 7420.0,
+          "status": "overdue",
+          "note": "Telefonische Erinnerung geplant am 06.11."
+        },
+        {
+          "invoiceNumber": "RE-2025-040",
+          "caseNumber": "M-2023-089",
+          "matter": "Mietrechtliche Streitigkeit Weber",
+          "client": "Jonas Weber",
+          "issueDate": "2025-10-25",
+          "dueDate": "2025-11-24",
+          "amount": 890.0,
+          "status": "open"
+        },
+        {
+          "invoiceNumber": "RE-2025-042",
+          "caseNumber": "S-2024-032",
+          "matter": "Steuerprüfung Contoso AG",
+          "client": "Contoso AG",
+          "issueDate": "2025-09-15",
+          "dueDate": "2025-10-15",
+          "amount": 5120.75,
+          "status": "paid",
+          "paidDate": "2025-10-22",
+          "note": "Ausgleich durch Sammelüberweisung"
+        },
+        {
+          "invoiceNumber": "RE-2025-045",
+          "caseNumber": "F-2024-011",
+          "matter": "Familienrechtliche Mediation Krause",
+          "client": "Familie Krause",
+          "issueDate": "2025-10-30",
+          "dueDate": "2025-11-29",
+          "amount": 1320.0,
+          "status": "open",
+          "note": "Ratenzahlung angefragt"
+        },
+        {
+          "invoiceNumber": "RE-2025-046",
+          "caseNumber": "N-2024-014",
+          "matter": "Nachlassverwaltung Petersen",
+          "client": "Erbengemeinschaft Petersen",
+          "issueDate": "2025-08-30",
+          "dueDate": "2025-09-29",
+          "amount": 2765.0,
+          "status": "overdue",
+          "note": "Weiterleitung an Buchhaltung zur Eskalation"
+        },
+        {
+          "invoiceNumber": "RE-2025-048",
+          "caseNumber": "K-2024-055",
+          "matter": "Kartellrechtliche Prüfung Nordwind",
+          "client": "Nordwind AG",
+          "issueDate": "2025-10-18",
+          "dueDate": "2025-11-17",
+          "amount": 3840.0,
+          "status": "open"
+        },
+        {
+          "invoiceNumber": "RE-2025-051",
+          "caseNumber": "D-2024-066",
+          "matter": "Datenschutz-Audit FutureLabs",
+          "client": "FutureLabs GmbH",
+          "issueDate": "2025-09-05",
+          "dueDate": "2025-10-05",
+          "amount": 4580.0,
+          "status": "paid",
+          "paidDate": "2025-10-03"
+        },
+        {
+          "invoiceNumber": "RE-2025-053",
+          "caseNumber": "B-2024-072",
+          "matter": "Baurechtliche Begleitung Skyline",
+          "client": "Skyline Projektentwicklung",
+          "issueDate": "2025-10-05",
+          "dueDate": "2025-11-04",
+          "amount": 6230.0,
+          "status": "overdue",
+          "note": "Letzte Erinnerung am 01.11. gesendet"
+        }
+      ]
+    </script>
+
+    <script src="assets/js/app.js" type="module"></script>
+    <script src="assets/js/open-items.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated Offene-Posten-Übersicht page with mock data and filtering controls
- implement styling and JavaScript to summarise receivable status counts and outstanding totals
- link the overview from the landing page and update the project ToDo list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690b0f6a40608320ab8596ba6161d4d2