### PR TITLE
Add mock email inbox module

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -52,8 +52,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 12. **Offene-Posten-Übersicht (Mock)** – Zeige Rechnungen mit Status „bezahlt“, „überfällig“, „offen“. Keine echte Datenbank nötig.
     Status: ✅ erledigt – 2025-11-05
 
-13. **E-Mail-Integration (Mock)** – Erstelle eine Demo-Inbox mit Nachrichtenliste und Detailansicht. Alle E-Mails sind Dummy-Einträge aus JSON.  
-    Status: ⬜
+13. **E-Mail-Integration (Mock)** – Erstelle eine Demo-Inbox mit Nachrichtenliste und Detailansicht. Alle E-Mails sind Dummy-Einträge aus JSON.
+    Status: ✅ erledigt – 2025-11-05
 
 14. **ERV-Paket-Builder (Mock)** – Simuliere das Erstellen eines elektronischen Rechtsverkehr-Pakets mit Upload-Liste und Validierungsanzeige.  
     Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2641,3 +2641,425 @@ body {
     min-width: unset;
   }
 }
+
+.mail-main {
+  width: min(1200px, 100%);
+  align-self: center;
+  align-items: stretch;
+}
+
+.mail-layout {
+  width: 100%;
+  background: #fff;
+  border-radius: 18px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(31, 60, 136, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+.mail-layout__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.mail-layout__description {
+  margin: 0.35rem 0 0;
+  max-width: 40rem;
+  color: #4b5563;
+}
+
+.mail-stats {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(8rem, auto);
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: rgba(47, 116, 192, 0.08);
+  border-radius: 14px;
+}
+
+.mail-stats__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  text-align: right;
+}
+
+.mail-stats__item dt {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  color: #1f3c88;
+  text-transform: uppercase;
+}
+
+.mail-stats__item dd {
+  margin: 0;
+  font-size: clamp(1.2rem, 2vw, 1.6rem);
+  font-weight: 700;
+  color: #1f2933;
+}
+
+.mail-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(31, 60, 136, 0.12);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.mail-toolbar__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.mail-toolbar__group--compact {
+  margin-left: auto;
+}
+
+.mail-toolbar__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.mail-toolbar input[type='search'],
+.mail-toolbar select {
+  min-width: 14rem;
+  border-radius: 10px;
+  border: 1px solid rgba(47, 116, 192, 0.3);
+  padding: 0.55rem 0.8rem;
+  font-size: 0.95rem;
+  background: #fff;
+}
+
+.mail-content {
+  display: flex;
+  gap: clamp(1rem, 3vw, 2rem);
+  align-items: stretch;
+}
+
+.mail-sidebar {
+  width: min(360px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mail-sidebar__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.mail-sidebar__summary {
+  margin: 0;
+  color: #4b5563;
+  font-weight: 500;
+}
+
+.mail-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 560px;
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.mail-list:focus {
+  outline: 3px solid rgba(47, 116, 192, 0.25);
+  outline-offset: 2px;
+}
+
+.mail-item {
+  text-align: left;
+  border: 1px solid rgba(31, 60, 136, 0.12);
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.mail-item:hover,
+.mail-item:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.12);
+}
+
+.mail-item--selected {
+  border-color: rgba(47, 116, 192, 0.4);
+  box-shadow: 0 16px 30px rgba(47, 116, 192, 0.18);
+}
+
+.mail-item--unread .mail-item__subject {
+  font-weight: 700;
+  color: #1f3c88;
+}
+
+.mail-item--archived {
+  opacity: 0.75;
+}
+
+.mail-item__subject {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.mail-item__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.mail-item__sender {
+  font-weight: 600;
+}
+
+.mail-item__snippet {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.mail-item__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.mail-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(47, 116, 192, 0.12);
+  color: #1f3c88;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.mail-detail {
+  flex: 1;
+  background: linear-gradient(145deg, rgba(47, 116, 192, 0.06), rgba(47, 116, 192, 0.01));
+  border-radius: 16px;
+  padding: clamp(1rem, 3vw, 2rem);
+  display: flex;
+}
+
+.mail-detail__placeholder {
+  margin: auto;
+  text-align: center;
+  max-width: 22rem;
+  color: #4b5563;
+}
+
+.mail-detail__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  width: 100%;
+}
+
+.mail-detail__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.mail-detail__meta {
+  margin: 0;
+  color: #4b5563;
+  font-weight: 500;
+}
+
+.mail-detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.mail-detail__properties {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.mail-detail__property {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.mail-detail__property dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: #1f3c88;
+  margin: 0;
+}
+
+.mail-detail__property dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #1f2933;
+}
+
+.mail-detail__property dd#mail-detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.mail-detail__address {
+  display: block;
+  color: #6b7280;
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.8rem;
+}
+
+.mail-detail__relative {
+  display: block;
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.mail-detail__section {
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(31, 60, 136, 0.08);
+}
+
+.mail-detail__section h4 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.mail-detail__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: #1f2933;
+}
+
+.mail-detail__body p {
+  margin: 0;
+  line-height: 1.7;
+}
+
+.mail-detail__body p + p {
+  margin-top: 0.35rem;
+}
+
+.mail-attachments {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #1f2933;
+  list-style: disc;
+}
+
+.mail-attachments a {
+  color: #2f74c0;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.mail-attachments a:hover {
+  text-decoration: underline;
+}
+
+.mail-empty {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.05);
+  color: #4b5563;
+  font-weight: 500;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: #1f3c88;
+  border: 1px solid rgba(47, 116, 192, 0.3);
+  font-size: 0.95rem;
+}
+
+.btn-ghost:hover {
+  background: rgba(47, 116, 192, 0.12);
+}
+
+.btn-ghost[aria-pressed='true'] {
+  background: rgba(47, 116, 192, 0.18);
+  border-color: rgba(47, 116, 192, 0.45);
+  color: #0f172a;
+}
+
+@media (max-width: 1080px) {
+  .mail-stats {
+    grid-auto-flow: row;
+    grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+    text-align: left;
+  }
+
+  .mail-stats__item {
+    text-align: left;
+  }
+
+  .mail-toolbar__group--compact {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 960px) {
+  .mail-content {
+    flex-direction: column;
+  }
+
+  .mail-sidebar {
+    width: 100%;
+  }
+
+  .mail-list {
+    max-height: 320px;
+  }
+}
+
+@media (max-width: 640px) {
+  .mail-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .mail-toolbar__group,
+  .mail-toolbar__group--compact {
+    width: 100%;
+  }
+
+  .mail-toolbar input[type='search'],
+  .mail-toolbar select {
+    width: 100%;
+  }
+}

--- a/assets/js/email-integration.js
+++ b/assets/js/email-integration.js
@@ -1,0 +1,644 @@
+const dataElement = document.getElementById('mail-data');
+
+function parseMailData() {
+  if (!dataElement) {
+    console.warn('Mail data element not found.');
+    return [];
+  }
+
+  try {
+    const raw = dataElement.textContent ?? '[]';
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.map(normalizeMessage).sort(sortByReceivedDesc);
+  } catch (error) {
+    console.error('Die Mail-Daten konnten nicht geladen werden.', error);
+    window.dispatchEvent(
+      new CustomEvent('verilex:error', {
+        detail: {
+          title: 'Maildaten nicht verfügbar',
+          message: 'Die Demo-Nachrichten konnten nicht interpretiert werden.',
+          details: error,
+        },
+      })
+    );
+    return [];
+  }
+}
+
+function sortByReceivedDesc(a, b) {
+  return b.receivedAt.getTime() - a.receivedAt.getTime();
+}
+
+function normalizeMessage(entry) {
+  const receivedAt = parseDate(entry.receivedAt);
+  const status = normalizeStatus(entry.status);
+  const generatedId =
+    entry.id ??
+    (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `mail-${Math.random().toString(36).slice(2, 10)}`);
+
+  return {
+    id: String(generatedId),
+    subject: String(entry.subject ?? 'Ohne Betreff').trim() || 'Ohne Betreff',
+    caseNumber: String(entry.caseNumber ?? '').trim() || '–',
+    client: String(entry.client ?? '').trim() || '–',
+    sender: normalizePerson(entry.sender),
+    to: normalizePeople(entry.to),
+    cc: normalizePeople(entry.cc),
+    receivedAt,
+    status,
+    tags: Array.isArray(entry.tags) ? entry.tags.map((tag) => String(tag).trim()).filter(Boolean) : [],
+    body: Array.isArray(entry.body)
+      ? entry.body.map((line) => String(line ?? '').trim()).filter(Boolean)
+      : [String(entry.body ?? '').trim()].filter(Boolean),
+    attachments: Array.isArray(entry.attachments)
+      ? entry.attachments
+          .map((attachment) => ({
+            name: String(attachment?.name ?? '').trim(),
+            url: String(attachment?.url ?? '').trim(),
+          }))
+          .filter((attachment) => attachment.name && attachment.url)
+      : [],
+    snippet: createSnippet(entry),
+  };
+}
+
+function normalizeStatus(value) {
+  const normalized = String(value ?? 'unread').toLowerCase();
+  if (normalized === 'archived') {
+    return 'archived';
+  }
+  if (normalized === 'read') {
+    return 'read';
+  }
+  return 'unread';
+}
+
+function normalizePerson(person) {
+  if (!person) {
+    return { name: 'Unbekannt', email: 'unbekannt@example.com' };
+  }
+
+  return {
+    name: String(person.name ?? 'Unbekannt').trim() || 'Unbekannt',
+    email: String(person.email ?? '').trim() || 'unbekannt@example.com',
+  };
+}
+
+function normalizePeople(list) {
+  if (!Array.isArray(list)) {
+    return [];
+  }
+  return list
+    .map((person) => normalizePerson(person))
+    .filter((person) => person.email && person.name);
+}
+
+function parseDate(value) {
+  const date = new Date(value ?? Date.now());
+  if (Number.isNaN(date.getTime())) {
+    return new Date();
+  }
+  return date;
+}
+
+function createSnippet(entry) {
+  if (Array.isArray(entry.body) && entry.body.length > 0) {
+    return truncateText(entry.body.join(' '), 140);
+  }
+  if (typeof entry.body === 'string') {
+    return truncateText(entry.body, 140);
+  }
+  return '';
+}
+
+function truncateText(text, length) {
+  if (!text) return '';
+  const trimmed = text.trim();
+  if (trimmed.length <= length) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, length - 1).trim()}…`;
+}
+
+const messages = parseMailData();
+const messageMap = new Map(messages.map((message) => [message.id, message]));
+
+const state = {
+  selectedId: null,
+  filters: {
+    query: '',
+    status: 'all',
+    tag: 'all',
+  },
+};
+
+const listElement = document.getElementById('mail-list');
+const emptyStateElement = document.getElementById('mail-empty-state');
+const listSummaryElement = document.getElementById('mail-list-summary');
+const searchInput = document.getElementById('mail-search');
+const statusFilter = document.getElementById('mail-status-filter');
+const tagFilter = document.getElementById('mail-tag-filter');
+const unreadShortcutButton = document.getElementById('mail-filter-unread');
+
+const detailContent = document.getElementById('mail-detail-content');
+const detailPlaceholder = document.getElementById('mail-detail-placeholder');
+const detailSubject = document.getElementById('mail-detail-subject');
+const detailCase = document.getElementById('mail-detail-case');
+const detailClient = document.getElementById('mail-detail-client');
+const detailSenderName = document.getElementById('mail-detail-sender-name');
+const detailSenderAddress = document.getElementById('mail-detail-sender-address');
+const detailRecipients = document.getElementById('mail-detail-recipients');
+const detailReceived = document.getElementById('mail-detail-received');
+const detailRelative = document.getElementById('mail-detail-relative');
+const detailStatus = document.getElementById('mail-detail-status');
+const detailTags = document.getElementById('mail-detail-tags');
+const detailBody = document.getElementById('mail-detail-body');
+const detailAttachments = document.getElementById('mail-detail-attachments');
+const toggleReadButton = document.getElementById('mail-action-toggle-read');
+const archiveButton = document.getElementById('mail-action-archive');
+
+const totalCountElement = document.getElementById('mail-count-total');
+const unreadCountElement = document.getElementById('mail-count-unread');
+const archivedCountElement = document.getElementById('mail-count-archived');
+
+const dateTimeFormatter = new Intl.DateTimeFormat('de-DE', {
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+const relativeFormatter = new Intl.RelativeTimeFormat('de', { numeric: 'auto' });
+
+function getFilteredMessages() {
+  return messages
+    .filter((message) => {
+      if (state.filters.status === 'unread' && message.status !== 'unread') {
+        return false;
+      }
+      if (state.filters.status === 'archived' && message.status !== 'archived') {
+        return false;
+      }
+      if (state.filters.tag !== 'all' && !message.tags.includes(state.filters.tag)) {
+        return false;
+      }
+      if (!state.filters.query) {
+        return true;
+      }
+      const haystack = [
+        message.subject,
+        message.client,
+        message.caseNumber,
+        message.sender.name,
+        message.sender.email,
+        message.tags.join(' '),
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      return haystack.includes(state.filters.query.toLowerCase());
+    })
+    .sort(sortByReceivedDesc);
+}
+
+function updateCounts() {
+  totalCountElement.textContent = messages.length.toString();
+  const unreadCount = messages.filter((message) => message.status === 'unread').length;
+  const archivedCount = messages.filter((message) => message.status === 'archived').length;
+  unreadCountElement.textContent = unreadCount.toString();
+  archivedCountElement.textContent = archivedCount.toString();
+}
+
+function updateUnreadShortcutState() {
+  const isStrictUnread =
+    state.filters.status === 'unread' &&
+    state.filters.tag === 'all' &&
+    state.filters.query === '';
+  unreadShortcutButton?.setAttribute('aria-pressed', isStrictUnread ? 'true' : 'false');
+}
+
+function updateFilterControls() {
+  if (searchInput) {
+    searchInput.value = state.filters.query;
+  }
+  if (statusFilter) {
+    statusFilter.value = state.filters.status;
+  }
+  if (tagFilter) {
+    tagFilter.value = state.filters.tag;
+  }
+  updateUnreadShortcutState();
+}
+
+function populateTagFilterOptions() {
+  if (!tagFilter) {
+    return;
+  }
+
+  const uniqueTags = new Set();
+  messages.forEach((message) => {
+    message.tags.forEach((tag) => uniqueTags.add(tag));
+  });
+
+  const currentValue = tagFilter.value || 'all';
+  const options = ['all', ...Array.from(uniqueTags).sort((a, b) => a.localeCompare(b, 'de'))];
+
+  tagFilter.innerHTML = '';
+  options.forEach((value) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value === 'all' ? 'Alle Kategorien' : value;
+    tagFilter.append(option);
+  });
+
+  if (options.includes(currentValue)) {
+    tagFilter.value = currentValue;
+  } else {
+    state.filters.tag = 'all';
+    tagFilter.value = 'all';
+  }
+}
+
+function renderList(filteredMessages) {
+  if (!listElement) {
+    return;
+  }
+
+  listElement.innerHTML = '';
+
+  if (filteredMessages.length === 0) {
+    listSummaryElement.textContent = '0 Nachrichten';
+    emptyStateElement?.removeAttribute('hidden');
+    listElement.setAttribute('aria-activedescendant', '');
+    return;
+  }
+
+  emptyStateElement?.setAttribute('hidden', '');
+  listSummaryElement.textContent =
+    filteredMessages.length === 1
+      ? '1 Nachricht'
+      : `${filteredMessages.length} Nachrichten`;
+
+  filteredMessages.forEach((message) => {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'mail-item';
+    if (message.status === 'unread') {
+      item.classList.add('mail-item--unread');
+    }
+    if (message.status === 'archived') {
+      item.classList.add('mail-item--archived');
+    }
+    const itemId = `mail-item-${message.id}`;
+    item.id = itemId;
+    if (message.id === state.selectedId) {
+      item.classList.add('mail-item--selected');
+    }
+    item.dataset.messageId = message.id;
+    item.setAttribute('role', 'option');
+    item.setAttribute('aria-selected', message.id === state.selectedId ? 'true' : 'false');
+
+    item.innerHTML = `
+      <span class="mail-item__subject">${escapeHtml(message.subject)}</span>
+      <span class="mail-item__meta">
+        <span class="mail-item__sender">${escapeHtml(message.sender.name)}</span>
+        <span class="mail-item__case">${escapeHtml(message.caseNumber)}</span>
+        <span class="mail-item__time">${formatRelative(message.receivedAt)}</span>
+      </span>
+      <span class="mail-item__snippet">${escapeHtml(message.snippet)}</span>
+    `;
+
+    if (message.tags.length > 0) {
+      const tagsContainer = document.createElement('div');
+      tagsContainer.className = 'mail-item__tags';
+      message.tags.slice(0, 3).forEach((tag) => {
+        const badge = document.createElement('span');
+        badge.className = 'mail-badge';
+        badge.textContent = tag;
+        tagsContainer.append(badge);
+      });
+      item.append(tagsContainer);
+    }
+
+    listElement.append(item);
+  });
+
+  const selectedItem = listElement.querySelector('.mail-item--selected');
+  if (selectedItem) {
+    listElement.setAttribute('aria-activedescendant', selectedItem.id);
+  } else {
+    listElement.setAttribute('aria-activedescendant', '');
+  }
+}
+
+function renderDetail(message) {
+  if (!detailContent || !detailPlaceholder) {
+    return;
+  }
+
+  if (!message) {
+    detailPlaceholder.removeAttribute('hidden');
+    detailContent.setAttribute('hidden', '');
+    return;
+  }
+
+  detailPlaceholder.setAttribute('hidden', '');
+  detailContent.removeAttribute('hidden');
+
+  detailSubject.textContent = message.subject;
+  detailCase.textContent = message.caseNumber;
+  detailClient.textContent = message.client;
+  detailSenderName.textContent = message.sender.name;
+  detailSenderAddress.textContent = formatSingleRecipient(message.sender);
+  detailRecipients.textContent = formatRecipientList(message.to, message.cc);
+  detailReceived.textContent = dateTimeFormatter.format(message.receivedAt);
+  detailRelative.textContent = formatRelative(message.receivedAt);
+  detailStatus.textContent = describeStatus(message.status);
+  renderTagList(detailTags, message.tags);
+  renderBody(detailBody, message.body);
+  renderAttachments(detailAttachments, message.attachments);
+
+  toggleReadButton.textContent =
+    message.status === 'unread' ? 'Als gelesen markieren' : 'Als ungelesen markieren';
+  toggleReadButton.setAttribute('data-status', message.status);
+
+  archiveButton.textContent = message.status === 'archived' ? 'In Posteingang verschieben' : 'Archivieren';
+}
+
+function describeStatus(status) {
+  switch (status) {
+    case 'unread':
+      return 'Ungelesen';
+    case 'archived':
+      return 'Archiviert';
+    default:
+      return 'Gelesen';
+  }
+}
+
+function formatRelative(date) {
+  const now = new Date();
+  const diffMs = date.getTime() - now.getTime();
+  const diffSeconds = Math.round(diffMs / 1000);
+  const absSeconds = Math.abs(diffSeconds);
+
+  if (absSeconds < 60) {
+    return relativeFormatter.format(Math.round(diffSeconds), 'second');
+  }
+  if (absSeconds < 3600) {
+    return relativeFormatter.format(Math.round(diffSeconds / 60), 'minute');
+  }
+  if (absSeconds < 86400) {
+    return relativeFormatter.format(Math.round(diffSeconds / 3600), 'hour');
+  }
+  if (absSeconds < 86400 * 30) {
+    return relativeFormatter.format(Math.round(diffSeconds / 86400), 'day');
+  }
+  return dateTimeFormatter.format(date);
+}
+
+function renderTagList(container, tags) {
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+  if (!tags || tags.length === 0) {
+    container.textContent = 'Keine';
+    return;
+  }
+  tags.forEach((tag) => {
+    const badge = document.createElement('span');
+    badge.className = 'mail-badge';
+    badge.textContent = tag;
+    container.append(badge);
+  });
+}
+
+function renderBody(container, paragraphs) {
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+  if (!paragraphs || paragraphs.length === 0) {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = 'Keine Nachricht verfügbar.';
+    fragment.append(paragraph);
+  } else {
+    paragraphs.forEach((text) => {
+      const paragraph = document.createElement('p');
+      paragraph.textContent = text;
+      fragment.append(paragraph);
+    });
+  }
+  container.append(fragment);
+}
+
+function renderAttachments(container, attachments) {
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+  if (!attachments || attachments.length === 0) {
+    const listItem = document.createElement('li');
+    listItem.textContent = 'Keine Anhänge vorhanden.';
+    container.append(listItem);
+    return;
+  }
+  attachments.forEach((attachment) => {
+    const listItem = document.createElement('li');
+    const link = document.createElement('a');
+    link.href = attachment.url;
+    link.textContent = attachment.name;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    listItem.append(link);
+    container.append(listItem);
+  });
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return char;
+    }
+  });
+}
+
+function formatSingleRecipient(person) {
+  if (!person) {
+    return '–';
+  }
+  return `${person.name} <${person.email}>`;
+}
+
+function formatRecipientList(to, cc) {
+  const segments = [];
+  if (Array.isArray(to) && to.length > 0) {
+    const toList = to.map((person) => formatSingleRecipient(person)).join(', ');
+    segments.push(`An: ${toList}`);
+  }
+  if (Array.isArray(cc) && cc.length > 0) {
+    const ccList = cc.map((person) => formatSingleRecipient(person)).join(', ');
+    segments.push(`Cc: ${ccList}`);
+  }
+  return segments.length > 0 ? segments.join(' · ') : '–';
+}
+
+function selectMessage(id) {
+  if (!messageMap.has(id)) {
+    return;
+  }
+  state.selectedId = id;
+  updateView();
+  focusSelectedItem();
+}
+
+function focusSelectedItem() {
+  if (!listElement) {
+    return;
+  }
+  const selectedItem = listElement.querySelector('.mail-item--selected');
+  selectedItem?.focus?.();
+}
+
+function toggleReadStatus() {
+  const message = messageMap.get(state.selectedId);
+  if (!message) {
+    return;
+  }
+  message.status = message.status === 'unread' ? 'read' : 'unread';
+  updateView();
+}
+
+function toggleArchiveStatus() {
+  const message = messageMap.get(state.selectedId);
+  if (!message) {
+    return;
+  }
+  message.status = message.status === 'archived' ? 'read' : 'archived';
+  updateView();
+}
+
+function updateView() {
+  const filtered = getFilteredMessages();
+
+  if (filtered.length === 0) {
+    state.selectedId = null;
+  } else if (!state.selectedId || !filtered.some((message) => message.id === state.selectedId)) {
+    state.selectedId = filtered[0].id;
+  }
+
+  renderList(filtered);
+  renderDetail(state.selectedId ? messageMap.get(state.selectedId) ?? null : null);
+  updateCounts();
+  updateFilterControls();
+}
+
+if (searchInput) {
+  searchInput.addEventListener('input', (event) => {
+    state.filters.query = event.target.value.trim();
+    updateView();
+  });
+}
+
+if (statusFilter) {
+  statusFilter.addEventListener('change', (event) => {
+    state.filters.status = event.target.value;
+    updateView();
+  });
+}
+
+if (tagFilter) {
+  tagFilter.addEventListener('change', (event) => {
+    state.filters.tag = event.target.value;
+    updateView();
+  });
+}
+
+if (unreadShortcutButton) {
+  unreadShortcutButton.addEventListener('click', () => {
+    const isActive = unreadShortcutButton.getAttribute('aria-pressed') === 'true';
+    if (isActive) {
+      state.filters.status = 'all';
+    } else {
+      state.filters.status = 'unread';
+      state.filters.tag = 'all';
+      state.filters.query = '';
+    }
+    updateView();
+  });
+}
+
+if (listElement) {
+  listElement.addEventListener('click', (event) => {
+    const item = event.target.closest('.mail-item');
+    if (!item) {
+      return;
+    }
+    selectMessage(item.dataset.messageId);
+  });
+
+  listElement.addEventListener('keydown', (event) => {
+    if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
+      return;
+    }
+    const filtered = getFilteredMessages();
+    if (filtered.length === 0) {
+      return;
+    }
+    event.preventDefault();
+    const currentIndex = filtered.findIndex((message) => message.id === state.selectedId);
+    if (event.key === 'ArrowUp' && currentIndex > 0) {
+      selectMessage(filtered[currentIndex - 1].id);
+    }
+    if (event.key === 'ArrowDown' && currentIndex < filtered.length - 1) {
+      selectMessage(filtered[currentIndex + 1].id);
+    }
+  });
+
+  listElement.addEventListener('focus', (event) => {
+    if (event.target === listElement) {
+      const selectedItem = listElement.querySelector('.mail-item--selected');
+      if (selectedItem) {
+        selectedItem.focus();
+      } else {
+        const firstItem = listElement.querySelector('.mail-item');
+        firstItem?.focus?.();
+      }
+    }
+  });
+}
+
+if (toggleReadButton) {
+  toggleReadButton.addEventListener('click', () => {
+    toggleReadStatus();
+  });
+}
+
+if (archiveButton) {
+  archiveButton.addEventListener('click', () => {
+    toggleArchiveStatus();
+  });
+}
+
+populateTagFilterOptions();
+updateView();
+

--- a/email-integration.html
+++ b/email-integration.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – E-Mail-Integration (Mock)</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>VeriLex Inbox</h1>
+      <p class="app-subtitle">
+        Demo einer kanzleitypischen E-Mail-Ansicht mit Nachrichtenliste, Detailbereich und Schnellaktionen.
+      </p>
+      <div class="welcome-actions">
+        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
+        <a class="btn btn-secondary" href="case-detail.html">Akten-Timeline</a>
+        <a class="btn btn-secondary" href="document-management.html">Dokumentenverwaltung</a>
+      </div>
+    </header>
+
+    <main class="app-main mail-main" aria-live="polite">
+      <section class="mail-layout" aria-labelledby="mail-title">
+        <header class="mail-layout__header">
+          <div>
+            <h2 id="mail-title">Demo-Inbox für Kanzleien</h2>
+            <p class="mail-layout__description">
+              Alle Nachrichten basieren auf Platzhalterdaten. Nutzen Sie Suche, Filter und Schnellaktionen, um typische Kanzleiabläufe nachzustellen.
+            </p>
+          </div>
+          <dl class="mail-stats" aria-label="Nachrichtenübersicht">
+            <div class="mail-stats__item">
+              <dt>Gesamt</dt>
+              <dd id="mail-count-total">0</dd>
+            </div>
+            <div class="mail-stats__item">
+              <dt>Ungelesen</dt>
+              <dd id="mail-count-unread">0</dd>
+            </div>
+            <div class="mail-stats__item">
+              <dt>Archiviert</dt>
+              <dd id="mail-count-archived">0</dd>
+            </div>
+          </dl>
+        </header>
+
+        <form class="mail-toolbar" role="search" aria-label="Nachrichten filtern" novalidate>
+          <div class="mail-toolbar__group">
+            <label class="mail-toolbar__label" for="mail-search">Schnellsuche</label>
+            <input
+              type="search"
+              id="mail-search"
+              name="query"
+              placeholder="Betreff, Mandant oder Aktenzeichen"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
+          <div class="mail-toolbar__group">
+            <label class="mail-toolbar__label" for="mail-status-filter">Status</label>
+            <select id="mail-status-filter" name="status">
+              <option value="all">Alle Nachrichten</option>
+              <option value="unread">Nur ungelesene</option>
+              <option value="archived">Archiv</option>
+            </select>
+          </div>
+          <div class="mail-toolbar__group">
+            <label class="mail-toolbar__label" for="mail-tag-filter">Kategorie</label>
+            <select id="mail-tag-filter" name="tag">
+              <option value="all">Alle Kategorien</option>
+            </select>
+          </div>
+          <div class="mail-toolbar__group mail-toolbar__group--compact">
+            <button type="button" id="mail-filter-unread" class="btn btn-ghost" aria-pressed="false">
+              Nur ungelesene anzeigen
+            </button>
+          </div>
+        </form>
+
+        <div class="mail-content">
+          <aside class="mail-sidebar" aria-labelledby="mail-list-title">
+            <header class="mail-sidebar__header">
+              <h3 id="mail-list-title">Nachrichten</h3>
+              <p id="mail-list-summary" class="mail-sidebar__summary" role="status">0 Nachrichten</p>
+            </header>
+            <div
+              id="mail-list"
+              class="mail-list"
+              role="listbox"
+              aria-describedby="mail-list-summary"
+              aria-labelledby="mail-list-title"
+              tabindex="0"
+            ></div>
+            <p id="mail-empty-state" class="mail-empty" hidden>
+              Für die aktuelle Filterkombination liegen keine Nachrichten vor.
+            </p>
+          </aside>
+
+          <article class="mail-detail" aria-labelledby="mail-detail-subject">
+            <div id="mail-detail-placeholder" class="mail-detail__placeholder">
+              <h3>Keine Nachricht ausgewählt</h3>
+              <p>Wählen Sie links eine Nachricht aus der Liste, um Details anzuzeigen.</p>
+            </div>
+
+            <div id="mail-detail-content" class="mail-detail__content" hidden>
+              <header class="mail-detail__header">
+                <div>
+                  <p class="mail-detail__meta">
+                    Akte <span id="mail-detail-case">–</span> · Mandant <span id="mail-detail-client">–</span>
+                  </p>
+                  <h3 id="mail-detail-subject">–</h3>
+                </div>
+                <div class="mail-detail__actions">
+                  <button type="button" id="mail-action-toggle-read" class="btn btn-secondary">
+                    Als gelesen markieren
+                  </button>
+                  <button type="button" id="mail-action-archive" class="btn btn-secondary">
+                    Archivieren
+                  </button>
+                </div>
+              </header>
+
+              <dl class="mail-detail__properties">
+                <div class="mail-detail__property">
+                  <dt>Von</dt>
+                  <dd>
+                    <span id="mail-detail-sender-name">–</span>
+                    <span class="mail-detail__address" id="mail-detail-sender-address">–</span>
+                  </dd>
+                </div>
+                <div class="mail-detail__property">
+                  <dt>An</dt>
+                  <dd id="mail-detail-recipients">–</dd>
+                </div>
+                <div class="mail-detail__property">
+                  <dt>Empfangen</dt>
+                  <dd>
+                    <span id="mail-detail-received">–</span>
+                    <span class="mail-detail__relative" id="mail-detail-relative">–</span>
+                  </dd>
+                </div>
+                <div class="mail-detail__property">
+                  <dt>Status</dt>
+                  <dd id="mail-detail-status">–</dd>
+                </div>
+                <div class="mail-detail__property">
+                  <dt>Kategorien</dt>
+                  <dd id="mail-detail-tags">–</dd>
+                </div>
+              </dl>
+
+              <section aria-labelledby="mail-detail-body-title" class="mail-detail__section">
+                <h4 id="mail-detail-body-title">Nachricht</h4>
+                <div id="mail-detail-body" class="mail-detail__body"></div>
+              </section>
+
+              <section aria-labelledby="mail-detail-attachments-title" class="mail-detail__section">
+                <h4 id="mail-detail-attachments-title">Anhänge</h4>
+                <ul id="mail-detail-attachments" class="mail-attachments"></ul>
+              </section>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details">
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">Seite neu laden</button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">Schließen</button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="application/json" id="mail-data">
+      [
+        {
+          "id": "mail-001",
+          "subject": "Fristverlängerung Weber ./. Wohnbau AG",
+          "caseNumber": "M-2023-089",
+          "client": "Jonas Weber",
+          "sender": {
+            "name": "Sabine Keller",
+            "email": "sabine.keller@wohnbau-ag.demo"
+          },
+          "to": [
+            { "name": "Dr. Jana Vogt", "email": "jana.vogt@verilex.demo" }
+          ],
+          "cc": [
+            { "name": "Fristen-Team", "email": "fristen@verilex.demo" }
+          ],
+          "receivedAt": "2025-11-05T08:15:00+01:00",
+          "status": "unread",
+          "tags": ["Frist", "Zivilrecht"],
+          "body": [
+            "Guten Morgen Frau Dr. Vogt,",
+            "wir bestätigen den Eingang Ihres Antrags auf Fristverlängerung und benötigen noch das unterschriebene Vergleichsangebot der Gegenseite. Bitte senden Sie uns die Unterlagen bis spätestens morgen, damit wir der Kammer antworten können.",
+            "Mit freundlichen Grüßen",
+            "Sabine Keller"
+          ],
+          "attachments": [
+            { "name": "Fristvermerk.pdf", "url": "assets/mock/verilex-demo.pdf" }
+          ]
+        },
+        {
+          "id": "mail-002",
+          "subject": "Mandant Schmidt – Rückfrage zur Honorarvereinbarung",
+          "caseNumber": "A-2024-017",
+          "client": "Eva Schmidt",
+          "sender": {
+            "name": "Eva Schmidt",
+            "email": "eva.schmidt@example.com"
+          },
+          "to": [
+            { "name": "Team Arbeitsrecht", "email": "arbeitsrecht@verilex.demo" }
+          ],
+          "receivedAt": "2025-11-04T18:42:00+01:00",
+          "status": "read",
+          "tags": ["Mandant", "Honorar"],
+          "body": [
+            "Guten Abend liebes Team,",
+            "könnten Sie mir bitte erläutern, welche Positionen in der Kostennote vom 28.10. enthalten sind? Außerdem benötige ich einen groben Ausblick, welche Aufwände im Dezember auf mich zukommen.",
+            "Vielen Dank und viele Grüße",
+            "Eva Schmidt"
+          ],
+          "attachments": []
+        },
+        {
+          "id": "mail-003",
+          "subject": "Neue Dokumente im Datenraum Contoso AG",
+          "caseNumber": "S-2024-032",
+          "client": "Contoso AG",
+          "sender": {
+            "name": "Datenraum Service",
+            "email": "noreply@contoso-dataroom.demo"
+          },
+          "to": [
+            { "name": "Steuer-Team", "email": "steuer@verilex.demo" }
+          ],
+          "receivedAt": "2025-11-04T13:05:00+01:00",
+          "status": "unread",
+          "tags": ["Dokument", "Due Diligence"],
+          "body": [
+            "Sehr geehrte Damen und Herren,",
+            "im Datenraum wurden drei neue Dokumente zur steuerlichen Sonderprüfung bereitgestellt: aktualisierte Bilanz, Verrechnungspreisdokumentation und ein Fragenkatalog der Finanzbehörde.",
+            "Bitte bestätigen Sie den Abruf innerhalb von 24 Stunden.",
+            "Freundliche Grüße",
+            "Ihr Contoso Datenraum Service"
+          ],
+          "attachments": []
+        },
+        {
+          "id": "mail-004",
+          "subject": "Besprechungstermin GreenTech – Agenda & Unterlagen",
+          "caseNumber": "I-2024-004",
+          "client": "GreenTech Holding",
+          "sender": {
+            "name": "Philipp Maier",
+            "email": "philipp.maier@greentech.demo"
+          },
+          "to": [
+            { "name": "Investitions-Team", "email": "invest@verilex.demo" }
+          ],
+          "cc": [
+            { "name": "Maria Fernandes", "email": "maria.fernandes@greentech.demo" }
+          ],
+          "receivedAt": "2025-11-03T09:20:00+01:00",
+          "status": "read",
+          "tags": ["Termin", "Mandant"],
+          "body": [
+            "Guten Tag zusammen,",
+            "anbei übersende ich die Agenda für den Strategieworkshop am 07.11. inklusive der Themenblöcke Compliance, Lieferkettenmonitoring und ESG-Reporting.",
+            "Könnten Sie außerdem prüfen, ob die Unterlagen zur Kartellrechtsfreigabe vollständig sind?",
+            "Beste Grüße",
+            "Philipp Maier"
+          ],
+          "attachments": [
+            { "name": "Agenda_Workshop.pdf", "url": "assets/mock/verilex-demo.pdf" }
+          ]
+        },
+        {
+          "id": "mail-005",
+          "subject": "ERV-Sendebericht verfügbar",
+          "caseNumber": "ERV-2025-014",
+          "client": "Systemmeldung",
+          "sender": {
+            "name": "ERV Poststelle",
+            "email": "no-reply@erv.justiz.demo"
+          },
+          "to": [
+            { "name": "Posteingang", "email": "posteingang@verilex.demo" }
+          ],
+          "receivedAt": "2025-11-02T22:10:00+01:00",
+          "status": "archived",
+          "tags": ["ERV", "System"],
+          "body": [
+            "Sehr geehrte Damen und Herren,",
+            "der elektronische Rechtsverkehr meldet den erfolgreichen Versand des Pakets ERV-2025-014 an das Amtsgericht Köln.",
+            "Der qualifizierte Sendebericht steht im Portal zum Abruf bereit.",
+            "Mit freundlichen Grüßen",
+            "Ihre ERV Poststelle"
+          ],
+          "attachments": []
+        }
+      ]
+    </script>
+
+    <script src="assets/js/app.js" type="module"></script>
+    <script src="assets/js/email-integration.js" type="module"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
           <a class="btn btn-secondary" href="performance-overview.html">Leistungsübersicht</a>
           <a class="btn btn-secondary" href="invoice-wizard.html">Rechnungs-Wizard</a>
           <a class="btn btn-secondary" href="open-items.html">Offene Posten</a>
+          <a class="btn btn-secondary" href="email-integration.html">E-Mail-Inbox</a>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add a dedicated email-integration page with demo data, message filters, and a detailed reader view
- implement inbox interactions (search, tag/status filters, keyboard navigation, and quick actions) in a new JavaScript module
- style the inbox layout, expose it from the landing page, and update the ToDo checklist entry

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_690b12bad9dc8320aa4573291edbbf69