### PR TITLE
Add ERV package builder mock page

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -56,7 +56,7 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
     Status: ✅ erledigt – 2025-11-05
 
 14. **ERV-Paket-Builder (Mock)** – Simuliere das Erstellen eines elektronischen Rechtsverkehr-Pakets mit Upload-Liste und Validierungsanzeige.  
-    Status: ⬜
+    Status: ✅ erledigt – 2025-11-05
 
 15. **Workflow-Designer (Mock)** – Implementiere eine einfache Drag-&-Drop-Fläche, auf der Prozess-Kacheln verbunden werden können.  
     Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3063,3 +3063,613 @@ body {
     width: 100%;
   }
 }
+
+/* ERV-Paket-Builder */
+.erv-builder-main {
+  width: 100%;
+  align-items: center;
+}
+
+.erv-board {
+  width: min(1200px, 100%);
+  background: #fff;
+  border-radius: 20px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(31, 60, 136, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 4vw, 2.75rem);
+}
+
+.erv-board__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: clamp(1rem, 3vw, 2rem);
+}
+
+.erv-board__description {
+  margin: 0.25rem 0 0;
+  max-width: 60ch;
+  color: #4b5563;
+}
+
+.erv-board__status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  min-width: 200px;
+}
+
+.erv-board__meta {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #1f2933;
+  text-align: right;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: rgba(47, 116, 192, 0.12);
+  color: #1f3c88;
+  border: 1px solid rgba(47, 116, 192, 0.25);
+}
+
+.status-pill--draft {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: #334155;
+}
+
+.status-pill--info {
+  background: rgba(47, 116, 192, 0.12);
+  border-color: rgba(47, 116, 192, 0.35);
+  color: #1f3c88;
+}
+
+.status-pill--success {
+  background: rgba(16, 185, 129, 0.16);
+  border-color: rgba(16, 185, 129, 0.3);
+  color: #047857;
+}
+
+.status-pill--warning {
+  background: rgba(245, 158, 11, 0.18);
+  border-color: rgba(245, 158, 11, 0.35);
+  color: #b45309;
+}
+
+.status-pill--error {
+  background: rgba(248, 113, 113, 0.2);
+  border-color: rgba(248, 113, 113, 0.45);
+  color: #b91c1c;
+}
+
+.status-pill--sample {
+  background: rgba(99, 102, 241, 0.18);
+  border-color: rgba(99, 102, 241, 0.35);
+  color: #4338ca;
+}
+
+.erv-progress {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.erv-progress__step {
+  position: relative;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  border-radius: 14px;
+  padding: 1rem 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.erv-progress__step::before {
+  content: attr(data-step);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #e0ecff;
+  color: #1f3c88;
+  font-weight: 600;
+}
+
+.erv-progress__title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.erv-progress__hint {
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.erv-progress__step.is-active {
+  border-color: rgba(47, 116, 192, 0.55);
+  box-shadow: 0 12px 30px rgba(47, 116, 192, 0.18);
+  background: rgba(47, 116, 192, 0.12);
+}
+
+.erv-progress__step.is-active::before {
+  background: #2f74c0;
+  color: #fff;
+}
+
+.erv-progress__step.is-complete {
+  background: rgba(16, 185, 129, 0.12);
+  border-color: rgba(16, 185, 129, 0.4);
+}
+
+.erv-progress__step.is-complete::before {
+  background: #10b981;
+  color: #fff;
+}
+
+.erv-board__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(260px, 1fr);
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  align-items: start;
+}
+
+.erv-form {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.erv-fieldset {
+  border: 1px solid rgba(47, 116, 192, 0.18);
+  border-radius: 18px;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  display: grid;
+  gap: 1rem 1.5rem;
+  background: rgba(47, 116, 192, 0.05);
+}
+
+.erv-fieldset__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.erv-fieldset__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.erv-toggle {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.erv-toggle__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+}
+
+.erv-toggle__label input {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.erv-upload {
+  display: grid;
+  gap: 1rem;
+}
+
+.erv-upload__header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.erv-upload__hint {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.erv-dropzone {
+  border: 2px dashed rgba(47, 116, 192, 0.4);
+  border-radius: 18px;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  background: rgba(47, 116, 192, 0.06);
+  display: grid;
+  gap: 0.6rem;
+  justify-items: center;
+  text-align: center;
+  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.erv-dropzone__icon {
+  font-size: 2.5rem;
+}
+
+.erv-dropzone__text {
+  margin: 0;
+  font-weight: 600;
+}
+
+.erv-dropzone__hint {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.9rem;
+}
+
+.erv-dropzone__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.erv-dropzone__input {
+  display: none;
+}
+
+.erv-dropzone.is-dragover {
+  border-color: rgba(16, 185, 129, 0.6);
+  background: rgba(16, 185, 129, 0.12);
+  transform: translateY(-2px);
+}
+
+.erv-documents {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.erv-documents__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.erv-documents__description {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.erv-documents__badge {
+  min-width: 140px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.erv-document-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.erv-document {
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 18px;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  background: #fff;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.erv-document__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.erv-document__info {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.erv-document__name {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.erv-document__meta {
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.erv-document__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  justify-content: flex-end;
+}
+
+.erv-document__remove {
+  align-self: start;
+  border: none;
+  background: transparent;
+  color: #b91c1c;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 8px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.erv-document__remove:hover {
+  background: rgba(248, 113, 113, 0.15);
+  color: #7f1d1d;
+}
+
+.erv-document__controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem 1rem;
+}
+
+.erv-document__control {
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #1f2933;
+}
+
+.erv-document__control select,
+.erv-document__control input[type='text'] {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.18);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.erv-document__control--checkbox {
+  align-items: center;
+  grid-template-columns: auto 1fr;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.erv-document__control--full {
+  grid-column: 1 / -1;
+}
+
+.erv-document__issues {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.erv-document__issue {
+  padding: 0.6rem 0.8rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+.erv-document__issue--error {
+  background: rgba(248, 113, 113, 0.18);
+  color: #7f1d1d;
+}
+
+.erv-document__issue--warning {
+  background: rgba(245, 158, 11, 0.16);
+  color: #92400e;
+}
+
+.erv-empty-state {
+  margin: 0;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.erv-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.erv-side-card {
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 18px;
+  background: #fff;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
+}
+
+.erv-side-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.erv-side-card__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.erv-validation-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.erv-validation__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: rgba(15, 23, 42, 0.03);
+}
+
+.erv-validation__icon {
+  font-size: 1.3rem;
+  line-height: 1;
+}
+
+.erv-validation__message {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2933;
+}
+
+.erv-validation__hint {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.erv-validation__item--error {
+  border-color: rgba(248, 113, 113, 0.4);
+  background: rgba(248, 113, 113, 0.16);
+}
+
+.erv-validation__item--warning {
+  border-color: rgba(245, 158, 11, 0.4);
+  background: rgba(245, 158, 11, 0.18);
+}
+
+.erv-validation__item--success {
+  border-color: rgba(16, 185, 129, 0.35);
+  background: rgba(16, 185, 129, 0.16);
+}
+
+.erv-validation__item--info {
+  border-color: rgba(47, 116, 192, 0.35);
+  background: rgba(47, 116, 192, 0.16);
+}
+
+.erv-validation-empty {
+  margin: 0;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.erv-sample-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.erv-sample {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.erv-sample:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.erv-sample__info {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.erv-sample__name {
+  font-weight: 600;
+}
+
+.erv-sample__meta {
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.erv-sample__add {
+  white-space: nowrap;
+}
+
+.erv-submit {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.erv-submit__feedback {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #047857;
+}
+
+@media (max-width: 1080px) {
+  .erv-board__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .erv-sidebar {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .erv-side-card {
+    flex: 1 1 280px;
+  }
+}
+
+@media (max-width: 720px) {
+  .erv-progress {
+    grid-template-columns: 1fr;
+  }
+
+  .erv-board__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .erv-board__status {
+    align-items: flex-start;
+  }
+
+  .erv-board__meta {
+    text-align: left;
+  }
+
+  .erv-document__header {
+    grid-template-columns: 1fr;
+  }
+
+  .erv-document__badges {
+    justify-content: flex-start;
+  }
+}

--- a/assets/js/erv-package-builder.js
+++ b/assets/js/erv-package-builder.js
@@ -1,0 +1,919 @@
+const MAX_PACKAGE_SIZE = 50 * 1024 * 1024; // 50 MB Mock-Grenze
+const WARNING_THRESHOLD = MAX_PACKAGE_SIZE * 0.8;
+
+const ROLE_OPTIONS = [
+  { value: 'hauptdokument', label: 'Hauptdokument' },
+  { value: 'beilage', label: 'Beilage' },
+  { value: 'nachweis', label: 'Nachweis' },
+  { value: 'sonstiges', label: 'Sonstiges' },
+];
+
+const VALIDATION_ICONS = {
+  error: '⚠️',
+  warning: 'ℹ️',
+  success: '✅',
+  info: '🔍',
+};
+
+const STATUS_PILL_CLASSES = {
+  draft: 'status-pill--draft',
+  info: 'status-pill--info',
+  success: 'status-pill--success',
+  warning: 'status-pill--warning',
+  error: 'status-pill--error',
+};
+
+function safeParseJson(elementId, fallback = []) {
+  const element = document.getElementById(elementId);
+  if (!element) {
+    return fallback;
+  }
+
+  try {
+    const rawText = element.textContent ?? '[]';
+    const parsed = JSON.parse(rawText);
+    return Array.isArray(parsed) ? parsed : fallback;
+  } catch (error) {
+    console.error(`JSON in Element #${elementId} konnte nicht geparst werden.`, error);
+    window.dispatchEvent(
+      new CustomEvent('verilex:error', {
+        detail: {
+          title: 'Datenfehler',
+          message: 'Die Demo-Daten für den ERV-Builder konnten nicht geladen werden.',
+          details: error,
+        },
+      })
+    );
+    return fallback;
+  }
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** exponent;
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}
+
+function generateId(prefix = 'doc') {
+  if (window.crypto?.randomUUID) {
+    return `${prefix}-${window.crypto.randomUUID()}`;
+  }
+
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function normaliseRole(role) {
+  const allowed = new Set(ROLE_OPTIONS.map((option) => option.value));
+  return allowed.has(role) ? role : 'beilage';
+}
+
+function initErvPackageBuilder() {
+  const form = document.getElementById('erv-form');
+  if (!form) {
+    return;
+  }
+
+  const packageNameInput = document.getElementById('erv-package-name');
+  const recipientSelect = document.getElementById('erv-recipient');
+  const submissionTypeSelect = document.getElementById('erv-submission-type');
+  const encryptionToggle = document.getElementById('erv-encryption');
+  const dropzone = document.getElementById('erv-dropzone');
+  const fileInput = document.getElementById('erv-file-input');
+  const clearButton = document.getElementById('erv-clear-files');
+  const selectButton = document.getElementById('erv-select-files');
+  const documentList = document.getElementById('erv-document-list');
+  const emptyState = document.getElementById('erv-document-empty');
+  const documentSummary = document.getElementById('erv-document-summary');
+  const documentCountBadge = document.getElementById('erv-documents-count');
+  const validationList = document.getElementById('erv-validation-list');
+  const validationEmpty = document.getElementById('erv-validation-empty');
+  const validationBadge = document.getElementById('erv-validation-badge');
+  const progressSteps = Array.from(document.querySelectorAll('.erv-progress__step'));
+  const packageSummary = document.getElementById('erv-package-summary');
+  const submitButton = document.getElementById('erv-submit');
+  const exportButton = document.getElementById('erv-export');
+  const submitFeedback = document.getElementById('erv-submit-feedback');
+  const sampleList = document.getElementById('erv-sample-list');
+
+  const recipients = safeParseJson('erv-recipient-data');
+  const sampleDocuments = safeParseJson('erv-sample-documents');
+
+  const state = {
+    documents: [],
+    validationResults: [],
+  };
+
+  function setFieldError(input, message) {
+    if (!input) {
+      return;
+    }
+
+    const errorId = input.getAttribute('aria-describedby');
+    const errorElement = errorId ? document.getElementById(errorId) : null;
+
+    if (message) {
+      input.classList.add('is-invalid');
+      input.setAttribute('aria-invalid', 'true');
+      if (errorElement) {
+        errorElement.textContent = message;
+      }
+    } else {
+      input.classList.remove('is-invalid');
+      input.removeAttribute('aria-invalid');
+      if (errorElement) {
+        errorElement.textContent = '';
+      }
+    }
+  }
+
+  function renderRecipientOptions() {
+    if (!recipientSelect) {
+      return;
+    }
+
+    const currentSelection = recipientSelect.value;
+    recipientSelect.innerHTML = '';
+
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    placeholder.textContent = 'Empfangsgericht auswählen';
+    recipientSelect.appendChild(placeholder);
+
+    recipients.forEach((recipient) => {
+      const option = document.createElement('option');
+      option.value = recipient.id;
+      option.textContent = recipient.name;
+      option.dataset.supportsPriority = recipient.supportsPriority ? 'true' : 'false';
+      option.dataset.address = recipient.address ?? '';
+      recipientSelect.appendChild(option);
+    });
+
+    if (currentSelection) {
+      recipientSelect.value = currentSelection;
+    }
+  }
+
+  function ensureMainDocumentAssigned(documents) {
+    if (documents.some((doc) => doc.role === 'hauptdokument')) {
+      return;
+    }
+
+    const firstDoc = documents[0];
+    if (firstDoc) {
+      firstDoc.role = 'hauptdokument';
+    }
+  }
+
+  function addDocuments(newDocs) {
+    if (!Array.isArray(newDocs) || newDocs.length === 0) {
+      return;
+    }
+
+    state.documents = state.documents.concat(newDocs);
+    ensureMainDocumentAssigned(state.documents);
+    synchronizeUI();
+  }
+
+  function createDocumentFromFile(file) {
+    if (!(file instanceof File)) {
+      return null;
+    }
+
+    return {
+      id: generateId('file'),
+      name: file.name ?? 'Unbenannt',
+      size: clamp(file.size ?? 0, 0, Number.MAX_SAFE_INTEGER),
+      type: file.type ?? 'unbekannt',
+      role: state.documents.length === 0 ? 'hauptdokument' : 'beilage',
+      signed: false,
+      description: '',
+      source: 'upload',
+      issues: [],
+    };
+  }
+
+  function createDocumentFromSample(sample) {
+    if (!sample) {
+      return null;
+    }
+
+    return {
+      id: generateId(sample.id ?? 'sample'),
+      name: sample.name ?? 'Demo-Dokument',
+      size: clamp(sample.size ?? 0, 0, Number.MAX_SAFE_INTEGER),
+      type: sample.type ?? 'application/octet-stream',
+      role: normaliseRole(sample.role),
+      signed: Boolean(sample.signed),
+      description: sample.description ?? '',
+      source: sample.id ?? 'sample',
+      isSample: true,
+      issues: [],
+    };
+  }
+
+  function handleFilesFromInput(files) {
+    const docs = Array.from(files ?? [])
+      .map((file) => createDocumentFromFile(file))
+      .filter(Boolean);
+
+    addDocuments(docs);
+  }
+
+  function removeDocument(docId) {
+    const index = state.documents.findIndex((doc) => doc.id === docId);
+    if (index === -1) {
+      return;
+    }
+
+    state.documents.splice(index, 1);
+    ensureMainDocumentAssigned(state.documents);
+    synchronizeUI();
+  }
+
+  function updateDocumentProperty(docId, property, value) {
+    const doc = state.documents.find((entry) => entry.id === docId);
+    if (!doc) {
+      return;
+    }
+
+    if (property === 'role') {
+      doc.role = normaliseRole(value);
+      if (doc.role === 'hauptdokument') {
+        state.documents
+          .filter((entry) => entry.id !== docId)
+          .forEach((entry) => {
+            if (entry.role === 'hauptdokument') {
+              entry.role = 'beilage';
+            }
+          });
+      } else if (!state.documents.some((entry) => entry.role === 'hauptdokument')) {
+        doc.role = 'hauptdokument';
+      }
+    } else if (property === 'signed') {
+      doc.signed = Boolean(value);
+    } else if (property === 'description') {
+      doc.description = String(value ?? '').slice(0, 160);
+    }
+
+    synchronizeUI();
+  }
+
+  function renderDocumentList() {
+    if (!documentList) {
+      return;
+    }
+
+    documentList.innerHTML = '';
+
+    if (state.documents.length === 0) {
+      emptyState?.removeAttribute('hidden');
+      return;
+    }
+
+    emptyState?.setAttribute('hidden', '');
+
+    const fragment = document.createDocumentFragment();
+
+    state.documents.forEach((doc) => {
+      const listItem = document.createElement('li');
+      listItem.className = 'erv-document';
+      listItem.dataset.docId = doc.id;
+
+      const header = document.createElement('div');
+      header.className = 'erv-document__header';
+
+      const info = document.createElement('div');
+      info.className = 'erv-document__info';
+
+      const name = document.createElement('span');
+      name.className = 'erv-document__name';
+      name.textContent = doc.name;
+
+      const meta = document.createElement('span');
+      meta.className = 'erv-document__meta';
+      meta.textContent = `${formatBytes(doc.size)} · ${doc.type || 'Unbekannt'}`;
+
+      info.append(name, meta);
+
+      const badgeContainer = document.createElement('div');
+      badgeContainer.className = 'erv-document__badges';
+
+      const roleBadge = document.createElement('span');
+      roleBadge.className = 'status-pill status-pill--info';
+      roleBadge.textContent = ROLE_OPTIONS.find((option) => option.value === doc.role)?.label ?? 'Beilage';
+      badgeContainer.appendChild(roleBadge);
+
+      if (doc.isSample) {
+        const sampleBadge = document.createElement('span');
+        sampleBadge.className = 'status-pill status-pill--sample';
+        sampleBadge.textContent = 'Demo';
+        badgeContainer.appendChild(sampleBadge);
+      }
+
+      const removeButton = document.createElement('button');
+      removeButton.type = 'button';
+      removeButton.className = 'erv-document__remove';
+      removeButton.dataset.docAction = 'remove';
+      removeButton.textContent = 'Entfernen';
+      removeButton.setAttribute('aria-label', `${doc.name} aus dem Paket entfernen`);
+
+      header.append(info, badgeContainer, removeButton);
+
+      const controls = document.createElement('div');
+      controls.className = 'erv-document__controls';
+
+      const roleControl = document.createElement('label');
+      roleControl.className = 'erv-document__control';
+      roleControl.textContent = 'Rolle';
+
+      const roleSelect = document.createElement('select');
+      roleSelect.dataset.docField = 'role';
+      roleSelect.setAttribute('aria-label', `Rolle für ${doc.name} auswählen`);
+
+      ROLE_OPTIONS.forEach((option) => {
+        const opt = document.createElement('option');
+        opt.value = option.value;
+        opt.textContent = option.label;
+        if (option.value === doc.role) {
+          opt.selected = true;
+        }
+        roleSelect.appendChild(opt);
+      });
+
+      roleControl.appendChild(roleSelect);
+
+      const signedControl = document.createElement('label');
+      signedControl.className = 'erv-document__control erv-document__control--checkbox';
+
+      const signedCheckbox = document.createElement('input');
+      signedCheckbox.type = 'checkbox';
+      signedCheckbox.dataset.docField = 'signed';
+      signedCheckbox.checked = Boolean(doc.signed);
+      signedCheckbox.setAttribute('aria-label', `Signaturstatus für ${doc.name}`);
+
+      const signedLabelText = document.createElement('span');
+      signedLabelText.textContent = 'Signiert';
+
+      signedControl.append(signedCheckbox, signedLabelText);
+
+      const descriptionControl = document.createElement('label');
+      descriptionControl.className = 'erv-document__control erv-document__control--full';
+      descriptionControl.textContent = 'Kurzbeschreibung';
+
+      const descriptionInput = document.createElement('input');
+      descriptionInput.type = 'text';
+      descriptionInput.dataset.docField = 'description';
+      descriptionInput.placeholder = 'Worum geht es in diesem Dokument?';
+      descriptionInput.maxLength = 160;
+      descriptionInput.value = doc.description ?? '';
+      descriptionInput.setAttribute('aria-label', `Kurzbeschreibung für ${doc.name}`);
+
+      descriptionControl.appendChild(descriptionInput);
+
+      controls.append(roleControl, signedControl, descriptionControl);
+
+      listItem.append(header, controls);
+
+      if (doc.issues?.length) {
+        const issueList = document.createElement('ul');
+        issueList.className = 'erv-document__issues';
+
+        doc.issues.forEach((issue) => {
+          const issueItem = document.createElement('li');
+          issueItem.className = `erv-document__issue erv-document__issue--${issue.level}`;
+          issueItem.textContent = issue.message;
+          issueList.appendChild(issueItem);
+        });
+
+        listItem.appendChild(issueList);
+      }
+
+      fragment.appendChild(listItem);
+    });
+
+    documentList.appendChild(fragment);
+  }
+
+  function renderSampleList() {
+    if (!sampleList) {
+      return;
+    }
+
+    sampleList.innerHTML = '';
+
+    const fragment = document.createDocumentFragment();
+
+    sampleDocuments.forEach((sample) => {
+      const listItem = document.createElement('li');
+      listItem.className = 'erv-sample';
+
+      const info = document.createElement('div');
+      info.className = 'erv-sample__info';
+
+      const title = document.createElement('span');
+      title.className = 'erv-sample__name';
+      title.textContent = sample.name ?? 'Demo-Dokument';
+
+      const meta = document.createElement('span');
+      meta.className = 'erv-sample__meta';
+      meta.textContent = `${ROLE_OPTIONS.find((option) => option.value === normaliseRole(sample.role))?.label ?? 'Beilage'} · ${formatBytes(sample.size ?? 0)}`;
+
+      info.append(title, meta);
+
+      const addButton = document.createElement('button');
+      addButton.type = 'button';
+      addButton.className = 'btn btn-secondary erv-sample__add';
+      addButton.dataset.sampleId = sample.id;
+      addButton.textContent = 'Übernehmen';
+
+      const isAlreadyIncluded = state.documents.some((doc) => doc.source === sample.id);
+      if (isAlreadyIncluded) {
+        addButton.disabled = true;
+        addButton.textContent = 'Bereits hinzugefügt';
+      }
+
+      listItem.append(info, addButton);
+      fragment.appendChild(listItem);
+    });
+
+    sampleList.appendChild(fragment);
+  }
+
+  function updateDocumentSummary() {
+    if (!documentSummary || !documentCountBadge) {
+      return;
+    }
+
+    const totalSize = state.documents.reduce((sum, doc) => sum + (doc.size ?? 0), 0);
+    const count = state.documents.length;
+    const mainDocument = state.documents.find((doc) => doc.role === 'hauptdokument');
+
+    documentSummary.textContent =
+      count === 0
+        ? 'Noch keine Dokumente aufgenommen.'
+        : `${count} Dokument${count === 1 ? '' : 'e'} · Gesamtgröße ${formatBytes(totalSize)}${
+            mainDocument ? ` · Hauptdokument: ${mainDocument.name}` : ''
+          }`;
+
+    const badgeText = `${count} Dokument${count === 1 ? '' : 'e'}`;
+    documentCountBadge.textContent = badgeText;
+  }
+
+  function updatePackageSummary() {
+    if (!packageSummary) {
+      return;
+    }
+
+    const totalSize = state.documents.reduce((sum, doc) => sum + (doc.size ?? 0), 0);
+    const recipientOption = recipientSelect?.selectedOptions?.[0];
+    const recipientName = recipientOption?.textContent || 'kein Empfänger';
+    const submissionType = submissionTypeSelect?.value || 'entwurf';
+
+    const segments = [];
+    if (packageNameInput?.value?.trim()) {
+      segments.push(packageNameInput.value.trim());
+    }
+
+    segments.push(recipientName);
+    segments.push(submissionType === 'priority' ? 'Fristsache' : submissionType === 'standard' ? 'Standardversand' : 'Entwurf');
+    segments.push(formatBytes(totalSize));
+
+    packageSummary.textContent = segments.join(' · ');
+  }
+
+  function updateValidationBadge() {
+    if (!validationBadge) {
+      return;
+    }
+
+    const hasErrors = state.validationResults.some((entry) => entry.level === 'error');
+    const hasWarnings = state.validationResults.some((entry) => entry.level === 'warning');
+    const hasDocuments = state.documents.length > 0;
+
+    const status = hasErrors ? 'error' : hasWarnings ? 'warning' : hasDocuments ? 'success' : 'draft';
+
+    validationBadge.textContent =
+      status === 'error'
+        ? 'Fehler vorhanden'
+        : status === 'warning'
+        ? 'Warnungen'
+        : status === 'success'
+        ? 'Bereit'
+        : 'Entwurf';
+
+    validationBadge.className = 'status-pill';
+    validationBadge.classList.add(STATUS_PILL_CLASSES[status]);
+  }
+
+  function updateProgressIndicator() {
+    if (!progressSteps.length) {
+      return;
+    }
+
+    const hasPackageMeta = Boolean(
+      packageNameInput?.value?.trim() && recipientSelect?.value && submissionTypeSelect?.value
+    );
+    const hasDocuments = state.documents.length > 0;
+    const hasErrors = state.validationResults.some((entry) => entry.level === 'error');
+    const hasValidations = state.validationResults.length > 0;
+
+    let activeStep = 1;
+
+    if (!hasPackageMeta) {
+      activeStep = 1;
+    } else if (!hasDocuments) {
+      activeStep = 2;
+    } else if (hasErrors) {
+      activeStep = 3;
+    } else if (hasValidations) {
+      activeStep = 4;
+    } else {
+      activeStep = 3;
+    }
+
+    progressSteps.forEach((step, index) => {
+      const stepIndex = index + 1;
+      step.classList.toggle('is-active', stepIndex === activeStep);
+      step.classList.toggle('is-complete', stepIndex < activeStep);
+    });
+  }
+
+  function updateValidationList() {
+    if (!validationList || !validationEmpty) {
+      return;
+    }
+
+    validationList.innerHTML = '';
+
+    if (state.validationResults.length === 0) {
+      validationEmpty.removeAttribute('hidden');
+      return;
+    }
+
+    validationEmpty.setAttribute('hidden', '');
+
+    const fragment = document.createDocumentFragment();
+
+    state.validationResults.forEach((entry) => {
+      const item = document.createElement('li');
+      item.className = `erv-validation__item erv-validation__item--${entry.level}`;
+
+      const icon = document.createElement('span');
+      icon.className = 'erv-validation__icon';
+      icon.textContent = VALIDATION_ICONS[entry.level] ?? VALIDATION_ICONS.info;
+
+      const text = document.createElement('div');
+      text.className = 'erv-validation__text';
+
+      const message = document.createElement('p');
+      message.className = 'erv-validation__message';
+      message.textContent = entry.message;
+
+      text.appendChild(message);
+
+      if (entry.hint) {
+        const hint = document.createElement('p');
+        hint.className = 'erv-validation__hint';
+        hint.textContent = entry.hint;
+        text.appendChild(hint);
+      }
+
+      item.append(icon, text);
+      fragment.appendChild(item);
+    });
+
+    validationList.appendChild(fragment);
+  }
+
+  function updateActions() {
+    const hasErrors = state.validationResults.some((entry) => entry.level === 'error');
+    const hasDocuments = state.documents.length > 0;
+
+    if (submitButton) {
+      submitButton.disabled = hasErrors || !hasDocuments;
+    }
+
+    if (exportButton) {
+      exportButton.disabled = !hasDocuments;
+    }
+  }
+
+  function collectFormData() {
+    return {
+      packageName: packageNameInput?.value?.trim() ?? '',
+      recipient: recipientSelect?.value ?? '',
+      submissionType: submissionTypeSelect?.value ?? '',
+      deadline: document.getElementById('erv-deadline')?.value ?? '',
+      message: document.getElementById('erv-message')?.value ?? '',
+      encryptionEnabled: encryptionToggle?.checked ?? false,
+      documents: state.documents.map((doc) => ({
+        id: doc.id,
+        name: doc.name,
+        size: doc.size,
+        type: doc.type,
+        role: doc.role,
+        signed: doc.signed,
+        description: doc.description,
+        source: doc.source ?? 'upload',
+      })),
+    };
+  }
+
+  function evaluateValidations() {
+    state.documents.forEach((doc) => {
+      doc.issues = [];
+    });
+
+    const results = [];
+
+    if (!packageNameInput?.value?.trim()) {
+      results.push({
+        level: 'error',
+        message: 'Bitte vergeben Sie einen Paketnamen.',
+        hint: 'Beispiel: "23 O 51/25 – Klageeinreichung"',
+      });
+      setFieldError(packageNameInput, 'Dieses Feld ist erforderlich.');
+    } else {
+      setFieldError(packageNameInput, '');
+    }
+
+    if (!recipientSelect?.value) {
+      results.push({
+        level: 'error',
+        message: 'Wählen Sie einen Empfänger aus.',
+        hint: 'Der elektronische Empfang ist an das zuständige Gericht zu adressieren.',
+      });
+      setFieldError(recipientSelect, 'Bitte wählen Sie ein Gericht.');
+    } else {
+      setFieldError(recipientSelect, '');
+    }
+
+    if (!submissionTypeSelect?.value) {
+      results.push({ level: 'error', message: 'Bitte geben Sie die Versandart an.' });
+      setFieldError(submissionTypeSelect, 'Bitte Versandart wählen.');
+    } else {
+      setFieldError(submissionTypeSelect, '');
+    }
+
+    if (state.documents.length === 0) {
+      results.push({
+        level: 'error',
+        message: 'Fügen Sie mindestens ein Dokument hinzu.',
+        hint: 'Ein ERV-Paket muss ein Hauptdokument enthalten.',
+      });
+    }
+
+    const mainDocuments = state.documents.filter((doc) => doc.role === 'hauptdokument');
+    if (mainDocuments.length === 0 && state.documents.length > 0) {
+      results.push({
+        level: 'error',
+        message: 'Markieren Sie genau ein Dokument als Hauptdokument.',
+      });
+    } else if (mainDocuments.length > 1) {
+      results.push({
+        level: 'error',
+        message: 'Nur ein Dokument darf als Hauptdokument markiert sein.',
+      });
+      mainDocuments.forEach((doc) => {
+        doc.issues.push({ level: 'error', message: 'Es sind mehrere Hauptdokumente markiert.' });
+      });
+    }
+
+    mainDocuments.forEach((doc) => {
+      if (!doc.signed) {
+        doc.issues.push({ level: 'error', message: 'Hauptdokument muss elektronisch signiert sein.' });
+        results.push({
+          level: 'error',
+          message: `Das Hauptdokument "${doc.name}" benötigt eine Signatur.`,
+        });
+      }
+    });
+
+    state.documents.forEach((doc) => {
+      if (doc.role !== 'hauptdokument' && !(doc.description ?? '').trim()) {
+        doc.issues.push({ level: 'warning', message: 'Bitte eine Kurzbeschreibung ergänzen.' });
+        results.push({
+          level: 'warning',
+          message: `Fügen Sie eine Kurzbeschreibung für "${doc.name}" hinzu.`,
+        });
+      }
+    });
+
+    const totalSize = state.documents.reduce((sum, doc) => sum + (doc.size ?? 0), 0);
+    if (totalSize > MAX_PACKAGE_SIZE) {
+      results.push({
+        level: 'error',
+        message: 'Die Paketgröße überschreitet die Mock-Grenze von 50 MB.',
+        hint: 'Entfernen Sie große Anhänge oder splitten Sie das Paket.',
+      });
+    } else if (totalSize > WARNING_THRESHOLD && totalSize <= MAX_PACKAGE_SIZE) {
+      results.push({
+        level: 'warning',
+        message: 'Die Paketgröße liegt nahe an der maximalen Grenze.',
+        hint: 'Erwägen Sie eine Komprimierung großer Dateien.',
+      });
+    }
+
+    if (submissionTypeSelect?.value === 'priority' && recipientSelect?.selectedOptions?.[0]) {
+      const supportsPriority = recipientSelect.selectedOptions[0].dataset.supportsPriority === 'true';
+      if (!supportsPriority) {
+        results.push({
+          level: 'error',
+          message: 'Dieses Gericht unterstützt keine priorisierte Übertragung.',
+          hint: 'Bitte wählen Sie Standardversand oder ein anderes Gericht.',
+        });
+      }
+    }
+
+    if (submissionTypeSelect?.value === 'priority' && encryptionToggle && !encryptionToggle.checked) {
+      results.push({
+        level: 'warning',
+        message: 'Für Fristsachen wird eine Verschlüsselung empfohlen.',
+        hint: 'Aktivieren Sie die End-zu-End-Verschlüsselung.',
+      });
+    }
+
+    state.validationResults = results;
+  }
+
+  function synchronizeUI() {
+    evaluateValidations();
+    renderDocumentList();
+    renderSampleList();
+    updateDocumentSummary();
+    updatePackageSummary();
+    updateValidationBadge();
+    updateValidationList();
+    updateProgressIndicator();
+    updateActions();
+  }
+
+  dropzone?.addEventListener('dragenter', (event) => {
+    event.preventDefault();
+    dropzone.classList.add('is-dragover');
+  });
+
+  dropzone?.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    dropzone.classList.add('is-dragover');
+  });
+
+  dropzone?.addEventListener('dragleave', (event) => {
+    if (event.target === dropzone) {
+      dropzone.classList.remove('is-dragover');
+    }
+  });
+
+  dropzone?.addEventListener('drop', (event) => {
+    event.preventDefault();
+    dropzone.classList.remove('is-dragover');
+    handleFilesFromInput(event.dataTransfer?.files ?? []);
+  });
+
+  dropzone?.addEventListener('click', () => {
+    fileInput?.click();
+  });
+
+  dropzone?.addEventListener('keydown', (event) => {
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault();
+      fileInput?.click();
+    }
+  });
+
+  selectButton?.addEventListener('click', () => fileInput?.click());
+
+  fileInput?.addEventListener('change', (event) => {
+    handleFilesFromInput(event.target.files ?? []);
+    fileInput.value = '';
+  });
+
+  clearButton?.addEventListener('click', () => {
+    state.documents = [];
+    synchronizeUI();
+  });
+
+  documentList?.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    if (target.dataset.docAction === 'remove') {
+      const docId = target.closest('.erv-document')?.dataset.docId;
+      if (docId) {
+        removeDocument(docId);
+      }
+    }
+  });
+
+  documentList?.addEventListener('change', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLSelectElement || target instanceof HTMLInputElement)) {
+      return;
+    }
+
+    const docElement = target.closest('.erv-document');
+    if (!docElement) {
+      return;
+    }
+
+    const docId = docElement.dataset.docId;
+    const field = target.dataset.docField;
+
+    if (!docId || !field) {
+      return;
+    }
+
+    if (target instanceof HTMLSelectElement) {
+      updateDocumentProperty(docId, field, target.value);
+    } else if (target instanceof HTMLInputElement && target.type === 'checkbox') {
+      updateDocumentProperty(docId, field, target.checked);
+    } else if (target instanceof HTMLInputElement) {
+      updateDocumentProperty(docId, field, target.value);
+    }
+  });
+
+  documentList?.addEventListener('input', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) {
+      return;
+    }
+
+    const docElement = target.closest('.erv-document');
+    if (!docElement) {
+      return;
+    }
+
+    const docId = docElement.dataset.docId;
+    const field = target.dataset.docField;
+    if (docId && field === 'description') {
+      updateDocumentProperty(docId, field, target.value);
+    }
+  });
+
+  sampleList?.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLButtonElement)) {
+      return;
+    }
+
+    const sampleId = target.dataset.sampleId;
+    if (!sampleId) {
+      return;
+    }
+
+    const sample = sampleDocuments.find((entry) => entry.id === sampleId);
+    const document = createDocumentFromSample(sample);
+    if (document) {
+      addDocuments([document]);
+    }
+  });
+
+  submitButton?.addEventListener('click', () => {
+    const hasErrors = state.validationResults.some((entry) => entry.level === 'error');
+    if (hasErrors) {
+      return;
+    }
+
+    const payload = collectFormData();
+    const reference = `ERV-${Date.now().toString(36).toUpperCase()}`;
+    submitFeedback.textContent = `Paket "${payload.packageName || 'Unbenannt'}" wurde erfolgreich simuliert übermittelt. Referenz: ${reference}.`;
+  });
+
+  exportButton?.addEventListener('click', () => {
+    const payload = collectFormData();
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `${payload.packageName ? payload.packageName.replace(/[^a-z0-9_-]+/gi, '-') : 'erv-paket'}.json`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+
+    submitFeedback.textContent = 'Metadaten wurden als JSON exportiert.';
+  });
+
+  form.addEventListener('input', () => {
+    synchronizeUI();
+  });
+
+  renderRecipientOptions();
+  renderSampleList();
+  synchronizeUI();
+}
+
+document.addEventListener('DOMContentLoaded', initErvPackageBuilder);

--- a/erv-package-builder.html
+++ b/erv-package-builder.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – ERV-Paket-Builder</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Elektronisches Rechtsverkehrspaket vorbereiten</h1>
+      <p class="app-subtitle">
+        Sammeln Sie Dokumente, prüfen Sie Pflichtangaben und simulieren Sie die Übergabe an das Gericht – vollständig im
+        Mock-Modus.
+      </p>
+    </header>
+
+    <main class="app-main erv-builder-main" aria-live="polite">
+      <nav class="case-breadcrumb" aria-label="Navigation">
+        <a class="case-breadcrumb__link" href="index.html">&larr; Zur Startseite</a>
+      </nav>
+
+      <section class="erv-board" aria-labelledby="erv-builder-title">
+        <header class="erv-board__header">
+          <div>
+            <h2 id="erv-builder-title">ERV-Paket-Builder (Mock)</h2>
+            <p class="erv-board__description" id="erv-builder-description">
+              Der Builder unterstützt dabei, ein strukturiertes ERV-Paket zusammenzustellen. Pflichtfelder, Signaturstatus und
+              Paketgröße werden in Echtzeit validiert.
+            </p>
+          </div>
+          <div class="erv-board__status" aria-live="polite">
+            <span id="erv-validation-badge" class="status-pill status-pill--draft">Entwurf</span>
+            <p id="erv-package-summary" class="erv-board__meta"></p>
+          </div>
+        </header>
+
+        <ol class="erv-progress" role="list" aria-label="Bearbeitungsschritte">
+          <li class="erv-progress__step" data-step="1">
+            <span class="erv-progress__title">Paketdaten</span>
+            <span class="erv-progress__hint">Mandant, Empfänger, Versandart</span>
+          </li>
+          <li class="erv-progress__step" data-step="2">
+            <span class="erv-progress__title">Dokumente</span>
+            <span class="erv-progress__hint">Upload &amp; Klassifizierung</span>
+          </li>
+          <li class="erv-progress__step" data-step="3">
+            <span class="erv-progress__title">Validierung</span>
+            <span class="erv-progress__hint">Pflichtfelder &amp; Größe</span>
+          </li>
+          <li class="erv-progress__step" data-step="4">
+            <span class="erv-progress__title">Übergabe</span>
+            <span class="erv-progress__hint">Übermittlung simulieren</span>
+          </li>
+        </ol>
+
+        <div class="erv-board__grid">
+          <form id="erv-form" class="erv-form" novalidate aria-describedby="erv-builder-description">
+            <fieldset class="erv-fieldset" aria-labelledby="erv-package-settings-title">
+              <legend id="erv-package-settings-title" class="erv-fieldset__title">Paketinformationen</legend>
+              <p class="erv-fieldset__hint">
+                Diese Angaben werden automatisch in die Versand-Metadaten übernommen. Pflichtfelder sind mit * gekennzeichnet.
+              </p>
+
+              <div class="form-grid">
+                <div class="form-field">
+                  <label for="erv-package-name">Paketname *</label>
+                  <input
+                    id="erv-package-name"
+                    name="packageName"
+                    type="text"
+                    required
+                    maxlength="80"
+                    placeholder="z. B. 23 O 51/25 – Klageeinreichung"
+                    aria-describedby="erv-package-name-error"
+                  />
+                  <p id="erv-package-name-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="erv-recipient">Empfänger *</label>
+                  <select id="erv-recipient" name="recipient" required aria-describedby="erv-recipient-error">
+                    <option value="" disabled selected>Empfangsgericht auswählen</option>
+                  </select>
+                  <p id="erv-recipient-error" class="field-error" role="status" aria-live="polite"></p>
+                </div>
+
+                <div class="form-field">
+                  <label for="erv-submission-type">Versandart *</label>
+                  <select id="erv-submission-type" name="submissionType" required aria-describedby="erv-submission-type-hint">
+                    <option value="" disabled selected>Bitte wählen</option>
+                    <option value="standard">Standard (Justizpostfach)</option>
+                    <option value="priority">Priorisiert (Fristsache)</option>
+                    <option value="draft">Entwurf speichern</option>
+                  </select>
+                  <p id="erv-submission-type-hint" class="form-field__hint">
+                    Die Versandart steuert Fristen und Empfangsbestätigungen.
+                  </p>
+                </div>
+
+                <div class="form-field">
+                  <label for="erv-deadline">Frist (optional)</label>
+                  <input id="erv-deadline" name="deadline" type="date" aria-describedby="erv-deadline-hint" />
+                  <p id="erv-deadline-hint" class="form-field__hint">Wird für die Erinnerungslogik genutzt.</p>
+                </div>
+
+                <div class="form-field form-field--full">
+                  <label for="erv-message">Begleitnachricht</label>
+                  <textarea
+                    id="erv-message"
+                    name="message"
+                    rows="3"
+                    maxlength="500"
+                    placeholder="Kurztext für das Gericht"
+                  ></textarea>
+                  <p class="form-field__hint">Die Nachricht wird im elektronischen Anschreiben mitgesendet.</p>
+                </div>
+              </div>
+
+              <div class="erv-toggle">
+                <label class="erv-toggle__label">
+                  <input type="checkbox" id="erv-encryption" name="encryption" checked />
+                  <span>End-zu-End-Verschlüsselung aktivieren</span>
+                </label>
+                <p class="form-field__hint">Empfohlen: Stellt sicher, dass sensible Inhalte geschützt übertragen werden.</p>
+              </div>
+            </fieldset>
+
+            <section class="erv-upload" aria-labelledby="erv-dropzone-title">
+              <header class="erv-upload__header">
+                <h3 id="erv-dropzone-title">Dokumente hinzufügen</h3>
+                <p class="erv-upload__hint">
+                  Ziehen Sie Dateien hierher oder nutzen Sie die Auswahl. Die Demo akzeptiert PDF, TIFF und Text-Dateien und
+                  analysiert die Meta-Daten lokal im Browser.
+                </p>
+              </header>
+
+              <div
+                id="erv-dropzone"
+                class="erv-dropzone"
+                role="button"
+                tabindex="0"
+                aria-describedby="erv-dropzone-hint"
+                aria-label="Dokumente für das ERV-Paket hinzufügen"
+              >
+                <div class="erv-dropzone__icon" aria-hidden="true">📄</div>
+                <p class="erv-dropzone__text">Dateien hier ablegen oder klicken, um auszuwählen</p>
+                <p id="erv-dropzone-hint" class="erv-dropzone__hint">Maximale Paketgröße (Mock): 50&nbsp;MB</p>
+                <div class="erv-dropzone__actions">
+                  <button type="button" class="btn btn-primary" id="erv-select-files">Dateien auswählen</button>
+                  <button type="button" class="btn btn-secondary" id="erv-clear-files">Liste leeren</button>
+                </div>
+                <input
+                  type="file"
+                  id="erv-file-input"
+                  class="erv-dropzone__input"
+                  multiple
+                  accept=".pdf,.tif,.tiff,.rtf,.txt,.doc,.docx"
+                  tabindex="-1"
+                  aria-hidden="true"
+                />
+              </div>
+            </section>
+
+            <section class="erv-documents" aria-labelledby="erv-document-list-title">
+              <header class="erv-documents__header">
+                <div>
+                  <h3 id="erv-document-list-title">Aktuelle Paketbestandteile</h3>
+                  <p class="erv-documents__description" id="erv-document-summary"></p>
+                </div>
+                <div class="erv-documents__badge" aria-live="polite">
+                  <span id="erv-documents-count" class="status-pill status-pill--info">0 Dokumente</span>
+                </div>
+              </header>
+
+              <ul id="erv-document-list" class="erv-document-list" role="list"></ul>
+              <p id="erv-document-empty" class="erv-empty-state" hidden>
+                Noch keine Dokumente hinzugefügt. Nutzen Sie die Drag-&amp;-Drop-Zone oder fügen Sie ein Demo-Dokument hinzu.
+              </p>
+            </section>
+          </form>
+
+          <aside class="erv-sidebar" aria-label="Validierung &amp; Simulation">
+            <section class="erv-side-card" aria-labelledby="erv-validation-title">
+              <h3 id="erv-validation-title">Validierungsstatus</h3>
+              <p class="erv-side-card__hint">
+                Fehler müssen behoben werden, bevor das Paket simuliert übermittelt werden kann. Warnungen sind optional.
+              </p>
+              <ul id="erv-validation-list" class="erv-validation-list" role="list"></ul>
+              <p id="erv-validation-empty" class="erv-validation-empty">Noch keine Prüfungen notwendig.</p>
+            </section>
+
+            <section class="erv-side-card" aria-labelledby="erv-sample-title">
+              <h3 id="erv-sample-title">Demo-Dokumente</h3>
+              <p class="erv-side-card__hint">
+                Nutzen Sie vorbereitete Beispieldateien, um den Prozess ohne eigene Dokumente zu testen.
+              </p>
+              <ul id="erv-sample-list" class="erv-sample-list" role="list"></ul>
+            </section>
+
+            <section class="erv-side-card" aria-labelledby="erv-submit-title">
+              <h3 id="erv-submit-title">Paket übermitteln</h3>
+              <p class="erv-side-card__hint">Ist alles grün, kann das Paket zur Justizpoststelle gesendet werden.</p>
+              <div class="erv-submit">
+                <button type="button" class="btn btn-primary" id="erv-submit" disabled>Übergabe simulieren</button>
+                <button type="button" class="btn btn-secondary" id="erv-export" disabled>Metadaten als JSON exportieren</button>
+              </div>
+              <p id="erv-submit-feedback" class="erv-submit__feedback" role="status" aria-live="polite"></p>
+            </section>
+          </aside>
+        </div>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button type="button" class="error-overlay__close" aria-label="Fehlermeldung schließen" data-error-action="dismiss">
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details" hidden>
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">Seite neu laden</button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">Schließen</button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="application/json" id="erv-recipient-data">
+      [
+        {
+          "id": "berlin-lg",
+          "name": "Landgericht Berlin",
+          "address": "Littenstraße 12-17, 10179 Berlin",
+          "supportsPriority": true
+        },
+        {
+          "id": "muc-ag",
+          "name": "Amtsgericht München",
+          "address": "Pacellistraße 5, 80333 München",
+          "supportsPriority": true
+        },
+        {
+          "id": "hamburg-fg",
+          "name": "Finanzgericht Hamburg",
+          "address": "Lübeckertordamm 4, 20099 Hamburg",
+          "supportsPriority": false
+        },
+        {
+          "id": "stuttgart-olg",
+          "name": "Oberlandesgericht Stuttgart",
+          "address": "Olgastraße 2, 70182 Stuttgart",
+          "supportsPriority": true
+        }
+      ]
+    </script>
+
+    <script type="application/json" id="erv-sample-documents">
+      [
+        {
+          "id": "sample-main",
+          "name": "Klageeingabe_Anlage.pdf",
+          "type": "application/pdf",
+          "size": 4820000,
+          "role": "hauptdokument",
+          "signed": true,
+          "description": "Begründung des Klagebegehrens"
+        },
+        {
+          "id": "sample-attachment",
+          "name": "Anlage_Beweisfoto1.tif",
+          "type": "image/tiff",
+          "size": 1640000,
+          "role": "beilage",
+          "signed": false,
+          "description": "Foto des beschädigten Fahrzeugs"
+        },
+        {
+          "id": "sample-proof",
+          "name": "Zustellnachweis.txt",
+          "type": "text/plain",
+          "size": 1200,
+          "role": "nachweis",
+          "signed": false,
+          "description": "Bestätigung der Zustellung an die Gegenseite"
+        }
+      ]
+    </script>
+
+    <script src="assets/js/app.js" type="module"></script>
+    <script src="assets/js/erv-package-builder.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated ERV package builder page with upload workflow, validation widgets, and sample data helpers
- implement client-side logic for drag-and-drop handling, metadata validation, and JSON export controls
- extend global styles with ERV-specific layouts, badges, validation list visuals, and responsive behaviour
- mark the ERV package builder task as complete in the project checklist

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690c7036511c83209219879484de3e5b