### PR TITLE
Add workflow designer mock interface

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -58,8 +58,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 14. **ERV-Paket-Builder (Mock)** – Simuliere das Erstellen eines elektronischen Rechtsverkehr-Pakets mit Upload-Liste und Validierungsanzeige.  
     Status: ✅ erledigt – 2025-11-05
 
-15. **Workflow-Designer (Mock)** – Implementiere eine einfache Drag-&-Drop-Fläche, auf der Prozess-Kacheln verbunden werden können.  
-    Status: ⬜
+15. **Workflow-Designer (Mock)** – Implementiere eine einfache Drag-&-Drop-Fläche, auf der Prozess-Kacheln verbunden werden können.
+    Status: ✅ erledigt – 2025-11-06
 
 16. **Fristen-Board** – Baue ein farbcodiertes Board mit Fristen (z. B. grün = offen, rot = überfällig).  
     Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3673,3 +3673,253 @@ body {
     justify-content: flex-start;
   }
 }
+
+/* Workflow-Designer */
+.workflow-designer-main {
+  width: min(1200px, 100%);
+  align-self: center;
+  align-items: stretch;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.workflow-designer {
+  width: 100%;
+  background: #fff;
+  border-radius: 20px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  box-shadow: 0 24px 55px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(31, 60, 136, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.workflow-designer__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.workflow-designer__description {
+  max-width: 60ch;
+  margin: 0.5rem 0 0;
+  color: #4b5563;
+}
+
+.workflow-designer__actions {
+  display: flex;
+  align-items: center;
+}
+
+.workflow-designer__layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) minmax(320px, 1fr) minmax(220px, 280px);
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+@media (max-width: 1024px) {
+  .workflow-designer__layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.workflow-palette,
+.workflow-inspector,
+.workflow-canvas-wrapper {
+  background: rgba(47, 116, 192, 0.05);
+  border-radius: 18px;
+  border: 1px solid rgba(47, 116, 192, 0.12);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.workflow-palette__hint,
+.workflow-canvas__hint,
+.workflow-connection-empty {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.workflow-palette__list {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.workflow-palette__item {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px dashed rgba(31, 60, 136, 0.4);
+  background: #fff;
+  color: #1f2933;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  cursor: grab;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.workflow-palette__item:active {
+  cursor: grabbing;
+}
+
+.workflow-palette__item:focus-visible {
+  outline: 3px solid rgba(47, 116, 192, 0.4);
+  outline-offset: 3px;
+}
+
+.workflow-canvas-wrapper {
+  position: relative;
+}
+
+.workflow-canvas__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.workflow-canvas {
+  position: relative;
+  min-height: clamp(320px, 60vh, 620px);
+  border-radius: 16px;
+  border: 2px dashed rgba(31, 60, 136, 0.35);
+  background-image: linear-gradient(rgba(47, 116, 192, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(47, 116, 192, 0.05) 1px, transparent 1px);
+  background-size: 24px 24px;
+  overflow: hidden;
+}
+
+.workflow-connections {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.workflow-node {
+  position: absolute;
+  min-width: 160px;
+  max-width: 220px;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  background: #fff;
+  border: 2px solid rgba(47, 116, 192, 0.45);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.16);
+  cursor: grab;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  transition: box-shadow 0.2s ease, transform 0.15s ease;
+  z-index: 1;
+}
+
+.workflow-node.is-selected {
+  border-color: #2f74c0;
+  box-shadow: 0 18px 32px rgba(47, 116, 192, 0.28);
+}
+
+.workflow-node__label {
+  font-weight: 600;
+  color: #1f2933;
+  text-align: left;
+}
+
+.workflow-node__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.workflow-node__button {
+  border: none;
+  background: rgba(47, 116, 192, 0.1);
+  color: #1f3c88;
+  padding: 0.25rem 0.4rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.workflow-node__button:hover {
+  background: rgba(47, 116, 192, 0.2);
+}
+
+.workflow-node:active {
+  cursor: grabbing;
+}
+
+.workflow-inspector {
+  position: relative;
+}
+
+.workflow-inspector__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.workflow-connection-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.workflow-connection-item {
+  background: #fff;
+  border-radius: 12px;
+  border: 1px solid rgba(47, 116, 192, 0.25);
+  padding: 0.75rem 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-weight: 500;
+}
+
+.workflow-connection-item button {
+  border: none;
+  background: rgba(220, 38, 38, 0.1);
+  color: #b91c1c;
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.workflow-connection-item button:hover {
+  background: rgba(220, 38, 38, 0.18);
+}
+
+.workflow-connection-empty {
+  font-style: italic;
+}
+
+.workflow-connection__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.workflow-connection__badge svg {
+  width: 1rem;
+  height: 1rem;
+  color: #2f74c0;
+}
+
+.workflow-node:focus-visible {
+  outline: 3px solid rgba(47, 116, 192, 0.35);
+  outline-offset: 4px;
+}
+

--- a/assets/js/workflow-designer.js
+++ b/assets/js/workflow-designer.js
@@ -1,0 +1,435 @@
+(function () {
+  const paletteItems = document.querySelectorAll('[data-workflow-step]');
+  const canvas = document.getElementById('workflow-canvas');
+  const connectionsSvg = document.getElementById('workflow-connections');
+  const clearButton = document.getElementById('workflow-clear');
+  const connectionList = document.getElementById('workflow-connection-list');
+  const connectionSummary = document.getElementById('workflow-connection-summary');
+  const connectionEmpty = document.getElementById('workflow-connection-empty');
+
+  if (!canvas || !connectionsSvg) {
+    console.warn('Workflow-Designer konnte nicht initialisiert werden.');
+    return;
+  }
+
+  const nodes = new Map();
+  let connections = [];
+  let selection = null;
+  let nodeCounter = 0;
+
+  function updateConnectionSummary() {
+    const count = connections.length;
+    if (!connectionSummary) return;
+
+    if (count === 0) {
+      connectionSummary.textContent = 'Keine Verbindungen vorhanden.';
+    } else if (count === 1) {
+      connectionSummary.textContent = '1 Verbindung aktiv.';
+    } else {
+      connectionSummary.textContent = `${count} Verbindungen aktiv.`;
+    }
+  }
+
+  function renderConnectionList() {
+    if (!connectionList || !connectionEmpty) return;
+
+    connectionList.innerHTML = '';
+    if (connections.length === 0) {
+      connectionEmpty.hidden = false;
+      return;
+    }
+
+    connectionEmpty.hidden = true;
+    const fragment = document.createDocumentFragment();
+
+    connections.forEach((connection) => {
+      const { id, fromId, toId } = connection;
+      const fromNode = nodes.get(fromId);
+      const toNode = nodes.get(toId);
+      if (!fromNode || !toNode) {
+        return;
+      }
+
+      const listItem = document.createElement('li');
+      listItem.className = 'workflow-connection-item';
+      listItem.dataset.connectionId = id;
+
+      const label = document.createElement('span');
+      label.className = 'workflow-connection__badge';
+      label.innerHTML = `
+        <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M8.59 16.59L13.17 12L8.59 7.41L10 6l6 6l-6 6z"
+          ></path>
+        </svg>
+        <span>${fromNode.label} → ${toNode.label}</span>
+      `;
+
+      const removeButton = document.createElement('button');
+      removeButton.type = 'button';
+      removeButton.textContent = 'Löschen';
+      removeButton.addEventListener('click', () => {
+        removeConnection(id);
+      });
+
+      listItem.append(label, removeButton);
+      fragment.append(listItem);
+    });
+
+    connectionList.append(fragment);
+  }
+
+  function createNode(label, position) {
+    const id = `node-${++nodeCounter}`;
+    const nodeElement = document.createElement('div');
+    nodeElement.className = 'workflow-node';
+    nodeElement.dataset.nodeId = id;
+    nodeElement.tabIndex = 0;
+
+    const nodeLabel = document.createElement('span');
+    nodeLabel.className = 'workflow-node__label';
+    nodeLabel.textContent = label;
+
+    const actions = document.createElement('div');
+    actions.className = 'workflow-node__actions';
+
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.className = 'workflow-node__button';
+    deleteButton.textContent = '×';
+    deleteButton.title = `${label} entfernen`;
+    deleteButton.setAttribute('aria-label', `${label} entfernen`);
+    deleteButton.addEventListener('click', (event) => {
+      event.stopPropagation();
+      removeNode(id);
+    });
+
+    actions.append(deleteButton);
+    nodeElement.append(nodeLabel, actions);
+
+    canvas.append(nodeElement);
+
+    const { x, y } = position;
+    positionNode(nodeElement, x, y);
+
+    enableDragging(nodeElement);
+    nodeElement.addEventListener('click', () => {
+      if (nodeElement.dataset.moved === 'true') {
+        delete nodeElement.dataset.moved;
+        return;
+      }
+      handleNodeSelection(id);
+    });
+
+    nodeElement.addEventListener('keydown', (event) => {
+      if (event.key === 'Delete' || event.key === 'Backspace') {
+        event.preventDefault();
+        removeNode(id);
+      }
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        handleNodeSelection(id);
+      }
+    });
+
+    nodes.set(id, { id, element: nodeElement, label });
+    announceSelection(null);
+    updateConnections();
+    return nodeElement;
+  }
+
+  function positionNode(element, x, y) {
+    const canvasRect = canvas.getBoundingClientRect();
+    const nodeRect = element.getBoundingClientRect();
+    const offsetX = x - canvasRect.left - nodeRect.width / 2;
+    const offsetY = y - canvasRect.top - nodeRect.height / 2;
+
+    const maxLeft = canvas.clientWidth - nodeRect.width;
+    const maxTop = canvas.clientHeight - nodeRect.height;
+
+    const clampedLeft = Math.max(0, Math.min(offsetX, maxLeft));
+    const clampedTop = Math.max(0, Math.min(offsetY, maxTop));
+
+    element.style.left = `${clampedLeft}px`;
+    element.style.top = `${clampedTop}px`;
+  }
+
+  function enableDragging(element) {
+    let pointerId = null;
+    let startX = 0;
+    let startY = 0;
+    let initialLeft = 0;
+    let initialTop = 0;
+    let moved = false;
+
+    const handlePointerDown = (event) => {
+      if (!event.isPrimary) return;
+      pointerId = event.pointerId;
+      element.setPointerCapture(pointerId);
+      element.classList.add('is-dragging');
+      element.dataset.dragging = 'true';
+      delete element.dataset.moved;
+      startX = event.clientX;
+      startY = event.clientY;
+      initialLeft = parseFloat(element.style.left || '0');
+      initialTop = parseFloat(element.style.top || '0');
+      moved = false;
+    };
+
+    const handlePointerMove = (event) => {
+      if (pointerId === null || event.pointerId !== pointerId) return;
+      const deltaX = event.clientX - startX;
+      const deltaY = event.clientY - startY;
+      if (!moved && (Math.abs(deltaX) > 2 || Math.abs(deltaY) > 2)) {
+        moved = true;
+        element.dataset.moved = 'true';
+      }
+      const newLeft = initialLeft + deltaX;
+      const newTop = initialTop + deltaY;
+
+      const nodeRect = element.getBoundingClientRect();
+      const maxLeft = canvas.clientWidth - nodeRect.width;
+      const maxTop = canvas.clientHeight - nodeRect.height;
+
+      const clampedLeft = Math.max(0, Math.min(newLeft, maxLeft));
+      const clampedTop = Math.max(0, Math.min(newTop, maxTop));
+
+      element.style.left = `${clampedLeft}px`;
+      element.style.top = `${clampedTop}px`;
+      updateConnections();
+    };
+
+    const handlePointerUp = (event) => {
+      if (pointerId === null || event.pointerId !== pointerId) return;
+      element.releasePointerCapture(pointerId);
+      pointerId = null;
+      element.classList.remove('is-dragging');
+      delete element.dataset.dragging;
+      if (!moved) {
+        delete element.dataset.moved;
+      }
+      updateConnections();
+    };
+
+    element.addEventListener('pointerdown', handlePointerDown);
+    element.addEventListener('pointermove', handlePointerMove);
+    element.addEventListener('pointerup', handlePointerUp);
+    element.addEventListener('pointercancel', handlePointerUp);
+  }
+
+  function announceSelection(nodeId) {
+    if (!canvas) return;
+    if (nodeId) {
+      canvas.dataset.currentSelection = nodeId;
+    } else {
+      canvas.dataset.currentSelection = '';
+    }
+  }
+
+  function handleNodeSelection(nodeId) {
+    const node = nodes.get(nodeId);
+    if (!node) return;
+
+    if (selection && selection !== nodeId) {
+      addConnection(selection, nodeId);
+      setSelection(null);
+      return;
+    }
+
+    if (selection === nodeId) {
+      setSelection(null);
+    } else {
+      setSelection(nodeId);
+    }
+  }
+
+  function setSelection(nodeId) {
+    selection = nodeId;
+    nodes.forEach(({ element }) => {
+      if (selection === element.dataset.nodeId) {
+        element.classList.add('is-selected');
+      } else {
+        element.classList.remove('is-selected');
+      }
+    });
+    announceSelection(nodeId);
+  }
+
+  function removeNode(nodeId) {
+    const node = nodes.get(nodeId);
+    if (!node) return;
+
+    node.element.remove();
+    nodes.delete(nodeId);
+    setSelection(null);
+    connections = connections.filter((connection) => {
+      return connection.fromId !== nodeId && connection.toId !== nodeId;
+    });
+    updateConnections();
+    renderConnectionList();
+    updateConnectionSummary();
+  }
+
+  function addConnection(fromId, toId) {
+    if (fromId === toId) {
+      return;
+    }
+    const exists = connections.some(
+      (connection) => connection.fromId === fromId && connection.toId === toId
+    );
+    if (exists) {
+      return;
+    }
+
+    const id = `connection-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+    connections.push({ id, fromId, toId });
+    updateConnections();
+    renderConnectionList();
+    updateConnectionSummary();
+  }
+
+  function removeConnection(connectionId) {
+    connections = connections.filter((connection) => connection.id !== connectionId);
+    updateConnections();
+    renderConnectionList();
+    updateConnectionSummary();
+  }
+
+  function updateConnections() {
+    if (!connectionsSvg) return;
+    const canvasRect = canvas.getBoundingClientRect();
+    connectionsSvg.setAttribute('viewBox', `0 0 ${canvasRect.width} ${canvasRect.height}`);
+    connectionsSvg.innerHTML = '';
+
+    const lineFragment = document.createDocumentFragment();
+
+    connections.forEach((connection) => {
+      const fromNode = nodes.get(connection.fromId);
+      const toNode = nodes.get(connection.toId);
+      if (!fromNode || !toNode) {
+        return;
+      }
+
+      const fromRect = fromNode.element.getBoundingClientRect();
+      const toRect = toNode.element.getBoundingClientRect();
+
+      const x1 = fromRect.left - canvasRect.left + fromRect.width / 2;
+      const y1 = fromRect.top - canvasRect.top + fromRect.height / 2;
+      const x2 = toRect.left - canvasRect.left + toRect.width / 2;
+      const y2 = toRect.top - canvasRect.top + toRect.height / 2;
+
+      const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+      line.setAttribute('x1', String(x1));
+      line.setAttribute('y1', String(y1));
+      line.setAttribute('x2', String(x2));
+      line.setAttribute('y2', String(y2));
+      line.setAttribute('stroke', 'rgba(47, 116, 192, 0.7)');
+      line.setAttribute('stroke-width', '3');
+      line.setAttribute('marker-end', 'url(#workflow-arrowhead)');
+      line.setAttribute('stroke-linecap', 'round');
+
+      lineFragment.append(line);
+    });
+
+    injectArrowhead();
+    connectionsSvg.append(lineFragment);
+  }
+
+  function injectArrowhead() {
+    if (connectionsSvg.querySelector('defs')) {
+      return;
+    }
+    const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+    const marker = document.createElementNS('http://www.w3.org/2000/svg', 'marker');
+    marker.setAttribute('id', 'workflow-arrowhead');
+    marker.setAttribute('markerWidth', '10');
+    marker.setAttribute('markerHeight', '10');
+    marker.setAttribute('refX', '6');
+    marker.setAttribute('refY', '3');
+    marker.setAttribute('orient', 'auto');
+    marker.setAttribute('markerUnits', 'strokeWidth');
+
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', 'M0,0 L6,3 L0,6 Z');
+    path.setAttribute('fill', 'rgba(47, 116, 192, 0.8)');
+
+    marker.append(path);
+    defs.append(marker);
+    connectionsSvg.prepend(defs);
+  }
+
+  function handlePaletteDragStart(event) {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const label = target.dataset.workflowStep;
+    if (!label) return;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'copy';
+    }
+    event.dataTransfer?.setData('text/plain', label);
+  }
+
+  function handleCanvasDragOver(event) {
+    event.preventDefault();
+  }
+
+  function handleCanvasDrop(event) {
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+    const label = event.dataTransfer?.getData('text/plain');
+    if (!label) return;
+    createNode(label, { x: event.clientX, y: event.clientY });
+    renderConnectionList();
+    updateConnectionSummary();
+  }
+
+  function clearWorkflow() {
+    nodes.forEach(({ element }) => element.remove());
+    nodes.clear();
+    connections = [];
+    setSelection(null);
+    updateConnections();
+    renderConnectionList();
+    updateConnectionSummary();
+  }
+
+  function handleKeyDown(event) {
+    if (event.key === 'Escape') {
+      setSelection(null);
+      return;
+    }
+    if (event.key !== 'Delete' && event.key !== 'Backspace') return;
+    if (!selection) return;
+    event.preventDefault();
+    removeNode(selection);
+  }
+
+  paletteItems.forEach((item) => {
+    item.addEventListener('dragstart', handlePaletteDragStart);
+    item.addEventListener('click', () => {
+      const rect = canvas.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      createNode(item.dataset.workflowStep ?? 'Baustein', { x: centerX, y: centerY });
+      renderConnectionList();
+      updateConnectionSummary();
+    });
+  });
+
+  canvas.addEventListener('dragover', handleCanvasDragOver);
+  canvas.addEventListener('drop', handleCanvasDrop);
+  canvas.addEventListener('keydown', handleKeyDown);
+  window.addEventListener('resize', updateConnections);
+
+  if (clearButton) {
+    clearButton.addEventListener('click', () => {
+      clearWorkflow();
+      canvas.focus();
+    });
+  }
+
+  updateConnectionSummary();
+})();

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
           <a class="btn btn-secondary" href="invoice-wizard.html">Rechnungs-Wizard</a>
           <a class="btn btn-secondary" href="open-items.html">Offene Posten</a>
           <a class="btn btn-secondary" href="email-integration.html">E-Mail-Inbox</a>
+          <a class="btn btn-secondary" href="workflow-designer.html">Workflow-Designer</a>
         </div>
       </section>
 

--- a/workflow-designer.html
+++ b/workflow-designer.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Workflow-Designer</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>VeriLex Demo</h1>
+      <p class="app-subtitle">Visueller Workflow-Designer (Mock)</p>
+    </header>
+
+    <main class="app-main workflow-designer-main" aria-live="polite">
+      <nav class="case-breadcrumb" aria-label="Brotkrumen">
+        <a class="case-breadcrumb__link" href="index.html">&larr; Zur Startseite</a>
+      </nav>
+
+      <section class="workflow-designer" aria-labelledby="workflow-designer-title">
+        <header class="workflow-designer__header">
+          <div>
+            <h2 id="workflow-designer-title">Abläufe modellieren &amp; visualisieren</h2>
+            <p class="workflow-designer__description">
+              Ziehen Sie Prozessschritte aus der linken Palette in die Fläche. Positionieren Sie sie frei und verbinden Sie
+              Arbeitsschritte durch Klicken der jeweiligen Kacheln. Alle Verbindungen erscheinen rechts in der Übersicht.
+            </p>
+          </div>
+          <div class="workflow-designer__actions">
+            <button type="button" id="workflow-clear" class="btn btn-secondary">Workflow zurücksetzen</button>
+          </div>
+        </header>
+
+        <div class="workflow-designer__layout">
+          <section
+            class="workflow-palette"
+            aria-labelledby="workflow-palette-title"
+            aria-describedby="workflow-palette-description"
+          >
+            <h3 id="workflow-palette-title">Prozessbausteine</h3>
+            <p id="workflow-palette-description" class="workflow-palette__hint">
+              Ziehen Sie Bausteine per Drag &amp; Drop in den Arbeitsbereich.
+            </p>
+            <ul class="workflow-palette__list" role="list">
+              <li>
+                <button type="button" class="workflow-palette__item" draggable="true" data-workflow-step="Mandatsanlage">
+                  Mandatsanlage
+                </button>
+              </li>
+              <li>
+                <button type="button" class="workflow-palette__item" draggable="true" data-workflow-step="Dokumentenprüfung">
+                  Dokumentenprüfung
+                </button>
+              </li>
+              <li>
+                <button type="button" class="workflow-palette__item" draggable="true" data-workflow-step="Fristenkontrolle">
+                  Fristenkontrolle
+                </button>
+              </li>
+              <li>
+                <button type="button" class="workflow-palette__item" draggable="true" data-workflow-step="Erstellung Schriftsatz">
+                  Erstellung Schriftsatz
+                </button>
+              </li>
+              <li>
+                <button type="button" class="workflow-palette__item" draggable="true" data-workflow-step="Versand über ERV">
+                  Versand über ERV
+                </button>
+              </li>
+              <li>
+                <button type="button" class="workflow-palette__item" draggable="true" data-workflow-step="Mandanteninformation">
+                  Mandanteninformation
+                </button>
+              </li>
+              <li>
+                <button type="button" class="workflow-palette__item" draggable="true" data-workflow-step="Archivierung">
+                  Archivierung
+                </button>
+              </li>
+            </ul>
+          </section>
+
+          <section class="workflow-canvas-wrapper" aria-labelledby="workflow-canvas-title">
+            <div class="workflow-canvas__header">
+              <h3 id="workflow-canvas-title">Arbeitsbereich</h3>
+              <p class="workflow-canvas__hint" id="workflow-canvas-hint">
+                Tipp: Klicken Sie einen Schritt an und anschließend einen weiteren, um eine Verbindung zu erzeugen.
+              </p>
+            </div>
+            <div
+              id="workflow-canvas"
+              class="workflow-canvas"
+              role="application"
+              aria-describedby="workflow-canvas-hint"
+              data-current-selection=""
+              tabindex="0"
+            >
+              <svg id="workflow-connections" class="workflow-connections" aria-hidden="true"></svg>
+            </div>
+          </section>
+
+          <section class="workflow-inspector" aria-labelledby="workflow-inspector-title">
+            <div class="workflow-inspector__header">
+              <h3 id="workflow-inspector-title">Verbindungen</h3>
+              <p class="workflow-inspector__summary" id="workflow-connection-summary" role="status"></p>
+            </div>
+            <ul id="workflow-connection-list" class="workflow-connection-list" role="list"></ul>
+            <p id="workflow-connection-empty" class="workflow-connection-empty">
+              Noch keine Verbindungen vorhanden. Wählen Sie nacheinander zwei Schritte aus, um eine Linie zu erstellen.
+            </p>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document" tabindex="-1">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details" hidden>
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">Seite neu laden</button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">Schließen</button>
+        </footer>
+      </div>
+    </div>
+
+    <script src="assets/js/app.js" defer></script>
+    <script src="assets/js/workflow-designer.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a workflow designer mock page with drag-and-drop nodes, connection handling, and reset controls
- extend shared styles to support the workflow palette, canvas, node controls, and connection list
- link the new workflow designer from the landing page and mark the corresponding ToDo item as complete

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_690c7411ac4883209157d5964b69226a