### PR TITLE
Add Fristen-Board page with color-coded deadlines

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -61,8 +61,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 15. **Workflow-Designer (Mock)** – Implementiere eine einfache Drag-&-Drop-Fläche, auf der Prozess-Kacheln verbunden werden können.
     Status: ✅ erledigt – 2025-11-06
 
-16. **Fristen-Board** – Baue ein farbcodiertes Board mit Fristen (z. B. grün = offen, rot = überfällig).  
-    Status: ⬜
+16. **Fristen-Board** – Baue ein farbcodiertes Board mit Fristen (z. B. grün = offen, rot = überfällig).
+    Status: ✅ erledigt – 2025-11-06
 
 17. **Termin-Kalender** – Erstelle eine Kalenderansicht mit anstehenden Gerichtsterminen oder Besprechungen.  
     Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3923,3 +3923,471 @@ body {
   outline-offset: 4px;
 }
 
+
+.deadline-main {
+  width: min(1200px, 100%);
+  align-self: center;
+  align-items: stretch;
+}
+
+.deadline-board {
+  width: 100%;
+  background: #fff;
+  border-radius: 20px;
+  padding: clamp(1.75rem, 4vw, 3.25rem);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(31, 60, 136, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 4vw, 2.4rem);
+}
+
+.deadline-board__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+  justify-content: space-between;
+}
+
+.deadline-board__header > div {
+  flex: 1 1 280px;
+  min-width: 260px;
+}
+
+.deadline-board__description {
+  margin: 0.75rem 0 0;
+  max-width: 38rem;
+  color: #4b5563;
+}
+
+.deadline-summary {
+  flex: 1 1 320px;
+  min-width: min(380px, 100%);
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.deadline-summary__item {
+  background: rgba(47, 116, 192, 0.08);
+  border-radius: 14px;
+  padding: 0.9rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  border: 1px solid rgba(47, 116, 192, 0.14);
+}
+
+.deadline-summary__item dt {
+  margin: 0;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #1f2933;
+}
+
+.deadline-summary__item dd {
+  margin: 0;
+  font-size: clamp(1.45rem, 3vw, 1.8rem);
+  font-weight: 700;
+  color: #1f3c88;
+}
+
+.deadline-summary__item--overdue {
+  background: rgba(224, 36, 36, 0.12);
+  border-color: rgba(224, 36, 36, 0.25);
+}
+
+.deadline-summary__item--overdue dd {
+  color: #b91c1c;
+}
+
+.deadline-summary__item--today {
+  background: rgba(249, 115, 22, 0.15);
+  border-color: rgba(249, 115, 22, 0.3);
+}
+
+.deadline-summary__item--today dd {
+  color: #c2410c;
+}
+
+.deadline-summary__item--soon {
+  background: rgba(245, 158, 11, 0.18);
+  border-color: rgba(245, 158, 11, 0.3);
+}
+
+.deadline-summary__item--soon dd {
+  color: #b45309;
+}
+
+.deadline-summary__item--upcoming {
+  background: rgba(34, 197, 94, 0.16);
+  border-color: rgba(34, 197, 94, 0.3);
+}
+
+.deadline-summary__item--upcoming dd {
+  color: #15803d;
+}
+
+.deadline-summary__item--completed {
+  background: rgba(55, 65, 81, 0.12);
+  border-color: rgba(55, 65, 81, 0.24);
+}
+
+.deadline-summary__item--completed dd {
+  color: #374151;
+}
+
+.deadline-summary__total {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #4b5563;
+}
+
+.deadline-filters {
+  display: grid;
+  gap: clamp(0.8rem, 2vw, 1.2rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
+}
+
+.deadline-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.deadline-filter__label {
+  font-weight: 600;
+  color: #1f2933;
+}
+
+.deadline-filter input[type='search'],
+.deadline-filter select {
+  border-radius: 10px;
+  border: 1px solid rgba(31, 60, 136, 0.15);
+  padding: 0.75rem 0.9rem;
+  font-size: 1rem;
+  font-family: inherit;
+  background: #f9fbff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.deadline-filter input[type='search']:focus,
+.deadline-filter select:focus {
+  border-color: rgba(47, 116, 192, 0.6);
+  box-shadow: 0 0 0 3px rgba(47, 116, 192, 0.25);
+  outline: none;
+}
+
+.deadline-filter--checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.deadline-filter--checkbox input {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: #2f74c0;
+}
+
+.deadline-filter-result {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #1f3c88;
+  background: rgba(47, 116, 192, 0.08);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+}
+
+.deadline-board__meta {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.deadline-columns {
+  display: grid;
+  gap: clamp(1.2rem, 3vw, 1.8rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  width: 100%;
+}
+
+.deadline-column {
+  background: rgba(243, 246, 255, 0.75);
+  border-radius: 16px;
+  border: 1px solid rgba(47, 116, 192, 0.18);
+  padding: clamp(1rem, 2.5vw, 1.4rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  min-height: 100%;
+}
+
+.deadline-column__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.deadline-column__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1f3c88;
+}
+
+.deadline-column__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: #fff;
+  border: 1px solid rgba(31, 60, 136, 0.2);
+  font-weight: 700;
+  color: #1f3c88;
+}
+
+.deadline-column__description {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.92rem;
+}
+
+.deadline-column__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.deadline-column__empty {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px dashed rgba(31, 60, 136, 0.2);
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.deadline-card {
+  position: relative;
+  background: #fff;
+  border-radius: 14px;
+  border: 1px solid rgba(31, 60, 136, 0.1);
+  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.1);
+  padding: 1.2rem 1.2rem 1.25rem 1.45rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  --deadline-accent: #2f74c0;
+}
+
+.deadline-card::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 5px;
+  border-radius: 12px 0 0 12px;
+  background: var(--deadline-accent);
+  opacity: 0.95;
+}
+
+.deadline-card:hover,
+.deadline-card:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 40px rgba(15, 23, 42, 0.16);
+}
+
+.deadline-card:focus-visible {
+  outline: 3px solid rgba(47, 116, 192, 0.35);
+  outline-offset: 3px;
+}
+
+.deadline-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.deadline-card__date {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2933;
+}
+
+.deadline-card__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  background: rgba(47, 116, 192, 0.15);
+  color: #1f3c88;
+  border: 1px solid rgba(47, 116, 192, 0.25);
+}
+
+.deadline-card__badge--overdue {
+  background: rgba(224, 36, 36, 0.12);
+  border-color: rgba(224, 36, 36, 0.25);
+  color: #b91c1c;
+}
+
+.deadline-card__badge--today {
+  background: rgba(249, 115, 22, 0.18);
+  border-color: rgba(249, 115, 22, 0.28);
+  color: #c2410c;
+}
+
+.deadline-card__badge--soon {
+  background: rgba(245, 158, 11, 0.18);
+  border-color: rgba(245, 158, 11, 0.28);
+  color: #b45309;
+}
+
+.deadline-card__badge--upcoming {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: rgba(34, 197, 94, 0.3);
+  color: #15803d;
+}
+
+.deadline-card__badge--completed {
+  background: rgba(55, 65, 81, 0.18);
+  border-color: rgba(55, 65, 81, 0.28);
+  color: #374151;
+}
+
+.deadline-card--overdue {
+  --deadline-accent: #e02424;
+}
+
+.deadline-card--today {
+  --deadline-accent: #f97316;
+}
+
+.deadline-card--soon {
+  --deadline-accent: #f59e0b;
+}
+
+.deadline-card--upcoming {
+  --deadline-accent: #22c55e;
+}
+
+.deadline-card--completed {
+  --deadline-accent: #4b5563;
+}
+
+.deadline-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.deadline-card__case {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.deadline-card__relative {
+  margin: 0;
+  font-weight: 600;
+  color: #1f3c88;
+  font-size: 0.95rem;
+}
+
+.deadline-card__meta {
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.deadline-card__meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.deadline-card__meta dt {
+  margin: 0;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6b7280;
+}
+
+.deadline-card__meta dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #1f2933;
+}
+
+.deadline-card__note {
+  margin: 0;
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(47, 116, 192, 0.08);
+  color: #1f3c88;
+  font-size: 0.95rem;
+}
+
+.deadline-card__tags {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.deadline-card__tag {
+  background: rgba(31, 60, 136, 0.1);
+  color: #1f3c88;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.deadline-empty-state {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  background: rgba(31, 60, 136, 0.08);
+  color: #1f3c88;
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .deadline-board__header {
+    flex-direction: column;
+  }
+
+  .deadline-summary {
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .deadline-filter--checkbox {
+    align-items: flex-start;
+  }
+
+  .deadline-filter--checkbox label {
+    line-height: 1.3;
+  }
+
+  .deadline-columns {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/js/deadline-board.js
+++ b/assets/js/deadline-board.js
@@ -1,0 +1,624 @@
+const dataElement = document.getElementById('deadline-data');
+
+const statusConfigurations = [
+  {
+    id: 'overdue',
+    label: 'Überfällig',
+    description: 'Fristen, deren Fälligkeit überschritten ist. Sofort handeln.',
+    emptyText: 'Aktuell liegen keine überfälligen Fristen vor.',
+  },
+  {
+    id: 'today',
+    label: 'Heute fällig',
+    description: 'Aufgaben, die noch am heutigen Tag abgeschlossen werden müssen.',
+    emptyText: 'Heute stehen keine weiteren Fristen an.',
+  },
+  {
+    id: 'soon',
+    label: 'In den nächsten 7 Tagen',
+    description: 'Fristen mit kurzem Vorlauf für die kommenden sieben Tage.',
+    emptyText: 'In den nächsten sieben Tagen stehen keine Fristen an.',
+  },
+  {
+    id: 'upcoming',
+    label: 'Geplant',
+    description: 'Fristen mit ausreichend Vorlaufzeit – ideal für proaktive Vorbereitung.',
+    emptyText: 'Es gibt derzeit keine langfristig geplanten Fristen.',
+  },
+  {
+    id: 'completed',
+    label: 'Erledigt',
+    description: 'Abgeschlossene Vorgänge zur Dokumentation und Nachverfolgung.',
+    emptyText: 'Es wurden noch keine Fristen als erledigt markiert.',
+  },
+];
+
+const allowedStatuses = new Set(statusConfigurations.map((status) => status.id));
+
+const numberFormatter = new Intl.NumberFormat('de-DE');
+const dateFormatter = new Intl.DateTimeFormat('de-DE', {
+  weekday: 'short',
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric',
+});
+const timestampFormatter = new Intl.DateTimeFormat('de-DE', {
+  dateStyle: 'long',
+  timeStyle: 'short',
+});
+const relativeFormatter = new Intl.RelativeTimeFormat('de', {
+  numeric: 'auto',
+});
+
+function parseISODate(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+
+  const [, yearStr, monthStr, dayStr] = match;
+  const year = Number.parseInt(yearStr, 10);
+  const month = Number.parseInt(monthStr, 10);
+  const day = Number.parseInt(dayStr, 10);
+
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+    return null;
+  }
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function normalizeDeadline(entry, index) {
+  const statusValue = String(entry.status ?? 'upcoming').toLowerCase();
+  const status = allowedStatuses.has(statusValue) ? statusValue : 'upcoming';
+  const tags = Array.isArray(entry.tags)
+    ? entry.tags
+        .map((tag) => String(tag ?? '').trim())
+        .filter(Boolean)
+    : [];
+
+  return {
+    id: String(entry.id ?? `deadline-${index}`),
+    title: String(entry.title ?? 'Unbenannte Frist').trim() || 'Unbenannte Frist',
+    caseNumber: String(entry.caseNumber ?? '').trim(),
+    client: String(entry.client ?? '').trim(),
+    dueDate: parseISODate(entry.dueDate),
+    dueDateRaw: String(entry.dueDate ?? '').trim(),
+    completedDate: parseISODate(entry.completedDate),
+    status,
+    responsible: String(entry.responsible ?? 'Unzugewiesen').trim() || 'Unzugewiesen',
+    type: String(entry.type ?? '').trim(),
+    notes: String(entry.notes ?? '').trim(),
+    location: String(entry.location ?? '').trim(),
+    tags,
+  };
+}
+
+function loadDeadlines() {
+  if (!dataElement) {
+    console.warn('Deadline data element not found.');
+    return [];
+  }
+
+  try {
+    const raw = dataElement.textContent ?? '[]';
+    const parsed = JSON.parse(raw);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.map((entry, index) => normalizeDeadline(entry, index));
+  } catch (error) {
+    console.error('Die Fristendaten konnten nicht interpretiert werden.', error);
+    window.dispatchEvent(
+      new CustomEvent('verilex:error', {
+        detail: {
+          title: 'Fehler beim Laden der Fristen',
+          message: 'Die Fristen konnten nicht geladen werden.',
+          details: error,
+        },
+      })
+    );
+    return [];
+  }
+}
+
+const deadlines = loadDeadlines();
+
+const columnsContainer = document.getElementById('deadline-columns');
+const emptyStateElement = document.getElementById('deadline-empty-state');
+const summaryTotalElement = document.getElementById('deadline-summary-total');
+const summaryElements = {
+  overdue: document.getElementById('deadline-summary-overdue'),
+  today: document.getElementById('deadline-summary-today'),
+  soon: document.getElementById('deadline-summary-soon'),
+  upcoming: document.getElementById('deadline-summary-upcoming'),
+  completed: document.getElementById('deadline-summary-completed'),
+};
+const filterResultElement = document.getElementById('deadline-filter-result');
+const lastSyncElement = document.getElementById('deadline-last-sync');
+
+const searchInput = document.getElementById('deadline-search');
+const statusFilter = document.getElementById('deadline-status-filter');
+const ownerFilter = document.getElementById('deadline-owner-filter');
+const hideCompletedToggle = document.getElementById('deadline-hide-completed');
+
+const filters = {
+  query: '',
+  queryRaw: '',
+  status: 'all',
+  owner: 'all',
+  hideCompleted: false,
+};
+
+function getTodayUTC() {
+  const today = new Date();
+  return Date.UTC(today.getFullYear(), today.getMonth(), today.getDate());
+}
+
+function toUTC(date) {
+  if (!(date instanceof Date)) {
+    return null;
+  }
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function describeRelativeDeadline(deadline) {
+  if (deadline.status === 'completed' && deadline.completedDate) {
+    return `Abgeschlossen am ${dateFormatter.format(deadline.completedDate)}`;
+  }
+
+  if (!deadline.dueDate) {
+    return 'Kein Fälligkeitsdatum hinterlegt';
+  }
+
+  const todayUTC = getTodayUTC();
+  const dueUTC = toUTC(deadline.dueDate);
+
+  if (dueUTC == null) {
+    return 'Kein Fälligkeitsdatum hinterlegt';
+  }
+
+  const diffDays = Math.round((dueUTC - todayUTC) / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) {
+    return 'Heute fällig';
+  }
+
+  if (diffDays > 0) {
+    if (diffDays === 1) {
+      return 'Fällig in 1 Tag';
+    }
+
+    if (diffDays <= 7) {
+      return `Fällig in ${diffDays} Tagen`;
+    }
+
+    return relativeFormatter.format(diffDays, 'day');
+  }
+
+  const overdueDays = Math.abs(diffDays);
+  return overdueDays === 1
+    ? 'Überfällig seit 1 Tag'
+    : `Überfällig seit ${overdueDays} Tagen`;
+}
+
+function formatDueDate(deadline) {
+  if (deadline.status === 'completed' && deadline.completedDate) {
+    return dateFormatter.format(deadline.completedDate);
+  }
+
+  if (!deadline.dueDate) {
+    return 'Datum offen';
+  }
+
+  return dateFormatter.format(deadline.dueDate);
+}
+
+function matchesSearch(deadline, query) {
+  if (!query) {
+    return true;
+  }
+
+  const haystack = [
+    deadline.title,
+    deadline.caseNumber,
+    deadline.client,
+    deadline.responsible,
+    deadline.type,
+    deadline.location,
+    deadline.tags.join(' '),
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  return haystack.includes(query);
+}
+
+function matchesStatus(deadline) {
+  switch (filters.status) {
+    case 'critical':
+      return deadline.status === 'overdue' || deadline.status === 'today';
+    case 'open':
+      return deadline.status !== 'completed';
+    case 'all':
+      return true;
+    default:
+      return deadline.status === filters.status;
+  }
+}
+
+function matchesOwner(deadline) {
+  if (filters.owner === 'all') {
+    return true;
+  }
+  return deadline.responsible === filters.owner;
+}
+
+function matchesFilters(deadline) {
+  if (filters.hideCompleted && deadline.status === 'completed') {
+    return false;
+  }
+
+  if (!matchesStatus(deadline)) {
+    return false;
+  }
+
+  if (!matchesOwner(deadline)) {
+    return false;
+  }
+
+  if (!matchesSearch(deadline, filters.query)) {
+    return false;
+  }
+
+  return true;
+}
+
+function sortDeadlinesForStatus(deadlineList, statusId) {
+  if (statusId === 'completed') {
+    return [...deadlineList].sort((a, b) => {
+      const aCompleted = a.completedDate ? a.completedDate.getTime() : Number.NEGATIVE_INFINITY;
+      const bCompleted = b.completedDate ? b.completedDate.getTime() : Number.NEGATIVE_INFINITY;
+      return bCompleted - aCompleted;
+    });
+  }
+
+  return [...deadlineList].sort((a, b) => {
+    const aTime = a.dueDate ? a.dueDate.getTime() : Number.POSITIVE_INFINITY;
+    const bTime = b.dueDate ? b.dueDate.getTime() : Number.POSITIVE_INFINITY;
+
+    if (aTime !== bTime) {
+      return aTime - bTime;
+    }
+
+    return a.title.localeCompare(b.title, 'de');
+  });
+}
+
+function createMetaItem(term, description) {
+  const wrapper = document.createElement('div');
+  const dt = document.createElement('dt');
+  dt.textContent = term;
+  const dd = document.createElement('dd');
+  dd.textContent = description || '–';
+  wrapper.append(dt, dd);
+  return wrapper;
+}
+
+function createTagList(tags) {
+  if (!tags || tags.length === 0) {
+    return null;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'deadline-card__tags';
+
+  tags.forEach((tag) => {
+    const item = document.createElement('li');
+    item.className = 'deadline-card__tag';
+    item.textContent = tag;
+    list.appendChild(item);
+  });
+
+  return list;
+}
+
+function createDeadlineCard(deadline) {
+  const card = document.createElement('article');
+  card.className = `deadline-card deadline-card--${deadline.status}`;
+  card.setAttribute('role', 'listitem');
+  card.setAttribute('tabindex', '0');
+
+  const header = document.createElement('header');
+  header.className = 'deadline-card__header';
+
+  const date = document.createElement('p');
+  date.className = 'deadline-card__date';
+  date.textContent = formatDueDate(deadline);
+  header.appendChild(date);
+
+  const badge = document.createElement('span');
+  badge.className = `deadline-card__badge deadline-card__badge--${deadline.status}`;
+  badge.textContent = statusConfigurations.find((status) => status.id === deadline.status)?.label ?? 'Frist';
+  header.appendChild(badge);
+
+  card.appendChild(header);
+
+  const title = document.createElement('h3');
+  title.className = 'deadline-card__title';
+  title.textContent = deadline.title;
+  card.appendChild(title);
+
+  const caseLine = document.createElement('p');
+  caseLine.className = 'deadline-card__case';
+  const caseParts = [deadline.caseNumber, deadline.client].filter(Boolean);
+  caseLine.textContent = caseParts.length > 0 ? caseParts.join(' · ') : 'Mandant unbekannt';
+  card.appendChild(caseLine);
+
+  const relative = document.createElement('p');
+  relative.className = 'deadline-card__relative';
+  relative.textContent = describeRelativeDeadline(deadline);
+  card.appendChild(relative);
+
+  const meta = document.createElement('dl');
+  meta.className = 'deadline-card__meta';
+  meta.append(
+    createMetaItem('Verantwortlich', deadline.responsible),
+    createMetaItem('Fristtyp', deadline.type || 'Nicht angegeben'),
+    createMetaItem('Ort', deadline.location || '–')
+  );
+  card.appendChild(meta);
+
+  if (deadline.notes) {
+    const notes = document.createElement('p');
+    notes.className = 'deadline-card__note';
+    notes.textContent = deadline.notes;
+    card.appendChild(notes);
+  }
+
+  const tagList = createTagList(deadline.tags);
+  if (tagList) {
+    card.appendChild(tagList);
+  }
+
+  return card;
+}
+
+function renderColumns(filtered) {
+  if (!columnsContainer) {
+    return;
+  }
+
+  columnsContainer.innerHTML = '';
+
+  statusConfigurations.forEach((status) => {
+    const column = document.createElement('section');
+    column.className = `deadline-column deadline-column--${status.id}`;
+    column.setAttribute('role', 'listitem');
+
+    const columnHeader = document.createElement('header');
+    columnHeader.className = 'deadline-column__header';
+
+    const title = document.createElement('h3');
+    title.className = 'deadline-column__title';
+    title.textContent = status.label;
+
+    const count = document.createElement('span');
+    count.className = 'deadline-column__count';
+    const itemsForStatus = filtered.filter((item) => item.status === status.id);
+    count.textContent = numberFormatter.format(itemsForStatus.length);
+
+    columnHeader.append(title, count);
+    column.appendChild(columnHeader);
+
+    const description = document.createElement('p');
+    description.className = 'deadline-column__description';
+    description.textContent = status.description;
+    column.appendChild(description);
+
+    const itemsContainer = document.createElement('div');
+    itemsContainer.className = 'deadline-column__items';
+    itemsContainer.setAttribute('role', 'list');
+
+    if (itemsForStatus.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'deadline-column__empty';
+      empty.textContent = status.emptyText;
+      itemsContainer.appendChild(empty);
+    } else {
+      const sortedItems = sortDeadlinesForStatus(itemsForStatus, status.id);
+      sortedItems.forEach((deadline) => {
+        itemsContainer.appendChild(createDeadlineCard(deadline));
+      });
+    }
+
+    column.appendChild(itemsContainer);
+    columnsContainer.appendChild(column);
+  });
+}
+
+function updateSummary(filtered, total) {
+  const aggregates = {
+    overdue: 0,
+    today: 0,
+    soon: 0,
+    upcoming: 0,
+    completed: 0,
+  };
+
+  filtered.forEach((deadline) => {
+    if (aggregates[deadline.status] != null) {
+      aggregates[deadline.status] += 1;
+    }
+  });
+
+  Object.entries(summaryElements).forEach(([status, element]) => {
+    if (element) {
+      element.textContent = numberFormatter.format(aggregates[status] ?? 0);
+    }
+  });
+
+  if (summaryTotalElement) {
+    summaryTotalElement.textContent = `Insgesamt ${numberFormatter.format(filtered.length)} Fristen im aktuellen Filter.`;
+  }
+
+  if (filterResultElement) {
+    const activeFilters = [];
+    if (filters.queryRaw) {
+      activeFilters.push(`Suche: „${filters.queryRaw}“`);
+    }
+    if (filters.status !== 'all') {
+      const statusOptionLabel = statusFilter?.selectedOptions?.[0]?.textContent ?? 'Statusfilter aktiv';
+      activeFilters.push(statusOptionLabel);
+    }
+    if (filters.owner !== 'all') {
+      activeFilters.push(`Verantwortlich: ${filters.owner}`);
+    }
+    if (filters.hideCompleted) {
+      activeFilters.push('Erledigte ausgeblendet');
+    }
+
+    const suffix = activeFilters.length > 0 ? activeFilters.join(' · ') : 'Keine Filter aktiv.';
+    filterResultElement.textContent = `${numberFormatter.format(filtered.length)} von ${numberFormatter.format(total)} Fristen angezeigt. ${suffix}`;
+  }
+}
+
+function updateEmptyState(filtered) {
+  if (!emptyStateElement) {
+    return;
+  }
+
+  if (filtered.length === 0) {
+    emptyStateElement.removeAttribute('hidden');
+  } else {
+    emptyStateElement.setAttribute('hidden', '');
+  }
+}
+
+function populateOwnerFilter() {
+  if (!ownerFilter) {
+    return;
+  }
+
+  const owners = Array.from(
+    new Set(
+      deadlines
+        .map((deadline) => deadline.responsible)
+        .filter((value) => typeof value === 'string' && value.trim() !== '')
+    )
+  ).sort((a, b) => a.localeCompare(b, 'de'));
+
+  owners.forEach((owner) => {
+    const option = document.createElement('option');
+    option.value = owner;
+    option.textContent = owner;
+    ownerFilter.appendChild(option);
+  });
+}
+
+function applyFilters() {
+  const filtered = deadlines.filter((deadline) => matchesFilters(deadline));
+  renderColumns(filtered);
+  updateSummary(filtered, deadlines.length);
+  updateEmptyState(filtered);
+}
+
+function initialiseFilters() {
+  if (searchInput) {
+    searchInput.addEventListener('input', (event) => {
+      const value = event.target.value ?? '';
+      filters.queryRaw = value.trim();
+      filters.query = filters.queryRaw.toLowerCase();
+      applyFilters();
+    });
+  }
+
+  if (statusFilter) {
+    statusFilter.addEventListener('change', (event) => {
+      filters.status = event.target.value ?? 'all';
+      applyFilters();
+    });
+  }
+
+  if (ownerFilter) {
+    ownerFilter.addEventListener('change', (event) => {
+      filters.owner = event.target.value ?? 'all';
+      applyFilters();
+    });
+  }
+
+  if (hideCompletedToggle) {
+    hideCompletedToggle.addEventListener('change', (event) => {
+      filters.hideCompleted = Boolean(event.target.checked);
+      applyFilters();
+    });
+  }
+}
+
+function updateTimestamp() {
+  if (!lastSyncElement) {
+    return;
+  }
+  lastSyncElement.textContent = `Aktualisiert am ${timestampFormatter.format(new Date())}.`;
+}
+
+function initDeadlineBoard() {
+  if (!columnsContainer) {
+    return;
+  }
+
+  populateOwnerFilter();
+  initialiseFilters();
+  updateTimestamp();
+  applyFilters();
+}
+
+if (Array.isArray(deadlines) && deadlines.length > 0) {
+  initDeadlineBoard();
+} else {
+  updateTimestamp();
+  updateSummary([], 0);
+  updateEmptyState([]);
+  if (columnsContainer) {
+    columnsContainer.innerHTML = '';
+    statusConfigurations.forEach((status) => {
+      const column = document.createElement('section');
+      column.className = `deadline-column deadline-column--${status.id}`;
+      column.setAttribute('role', 'listitem');
+
+      const columnHeader = document.createElement('header');
+      columnHeader.className = 'deadline-column__header';
+
+      const title = document.createElement('h3');
+      title.className = 'deadline-column__title';
+      title.textContent = status.label;
+
+      const count = document.createElement('span');
+      count.className = 'deadline-column__count';
+      count.textContent = '0';
+
+      columnHeader.append(title, count);
+      column.appendChild(columnHeader);
+
+      const description = document.createElement('p');
+      description.className = 'deadline-column__description';
+      description.textContent = status.description;
+      column.appendChild(description);
+
+      const empty = document.createElement('p');
+      empty.className = 'deadline-column__empty';
+      empty.textContent = status.emptyText;
+      column.appendChild(empty);
+
+      columnsContainer.appendChild(column);
+    });
+  }
+}

--- a/deadline-board.html
+++ b/deadline-board.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Fristen-Board</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Fristen-Board</h1>
+      <p class="app-subtitle">
+        Priorisieren Sie juristische Fristen, erkennen Sie Engpässe frühzeitig und koordinieren Sie Zuständigkeiten.
+      </p>
+      <div class="welcome-actions">
+        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
+        <a class="btn btn-secondary" href="case-detail.html">Zu einer Akte</a>
+        <a class="btn btn-secondary" href="open-items.html">Offene Posten</a>
+      </div>
+    </header>
+
+    <main class="app-main deadline-main" aria-live="polite">
+      <section class="deadline-board" aria-labelledby="deadline-board-title">
+        <header class="deadline-board__header">
+          <div>
+            <h2 id="deadline-board-title">Fristen nach Dringlichkeit</h2>
+            <p class="deadline-board__description">
+              Das Board gruppiert alle Demo-Fristen nach ihrem Status. Jede Karte zeigt neben Fälligkeit und Mandant auch die
+              verantwortliche Person und optionale Notizen.
+            </p>
+          </div>
+          <dl class="deadline-summary" aria-label="Fristenzusammenfassung">
+            <div class="deadline-summary__item deadline-summary__item--overdue">
+              <dt>Überfällig</dt>
+              <dd id="deadline-summary-overdue">0</dd>
+            </div>
+            <div class="deadline-summary__item deadline-summary__item--today">
+              <dt>Heute fällig</dt>
+              <dd id="deadline-summary-today">0</dd>
+            </div>
+            <div class="deadline-summary__item deadline-summary__item--soon">
+              <dt>In den nächsten 7 Tagen</dt>
+              <dd id="deadline-summary-soon">0</dd>
+            </div>
+            <div class="deadline-summary__item deadline-summary__item--upcoming">
+              <dt>Geplant</dt>
+              <dd id="deadline-summary-upcoming">0</dd>
+            </div>
+            <div class="deadline-summary__item deadline-summary__item--completed">
+              <dt>Erledigt</dt>
+              <dd id="deadline-summary-completed">0</dd>
+            </div>
+          </dl>
+        </header>
+
+        <p id="deadline-summary-total" class="deadline-summary__total" role="status">
+          Insgesamt 0 Fristen im aktuellen Filter.
+        </p>
+
+        <form class="deadline-filters" aria-label="Fristen filtern" novalidate>
+          <div class="deadline-filter">
+            <label class="deadline-filter__label" for="deadline-search">Schnellsuche</label>
+            <input
+              type="search"
+              id="deadline-search"
+              name="search"
+              placeholder="Nach Frist, Mandant oder Aktenzeichen suchen"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
+          <div class="deadline-filter">
+            <label class="deadline-filter__label" for="deadline-status-filter">Status</label>
+            <select id="deadline-status-filter" name="status">
+              <option value="all">Alle Fristen</option>
+              <option value="critical">Nur kritische (heute &amp; überfällig)</option>
+              <option value="open">Alle offenen</option>
+              <option value="overdue">Überfällig</option>
+              <option value="today">Heute fällig</option>
+              <option value="soon">In den nächsten 7 Tagen</option>
+              <option value="upcoming">Geplant</option>
+              <option value="completed">Erledigt</option>
+            </select>
+          </div>
+          <div class="deadline-filter">
+            <label class="deadline-filter__label" for="deadline-owner-filter">Verantwortlich</label>
+            <select id="deadline-owner-filter" name="owner">
+              <option value="all">Alle Personen</option>
+            </select>
+          </div>
+          <div class="deadline-filter deadline-filter--checkbox">
+            <input type="checkbox" id="deadline-hide-completed" name="hideCompleted" />
+            <label for="deadline-hide-completed">Erledigte Fristen ausblenden</label>
+          </div>
+        </form>
+
+        <p id="deadline-filter-result" class="deadline-filter-result" role="status">
+          Keine Filter aktiv.
+        </p>
+
+        <p id="deadline-last-sync" class="deadline-board__meta" role="status"></p>
+
+        <div id="deadline-columns" class="deadline-columns" role="list"></div>
+
+        <p id="deadline-empty-state" class="deadline-empty-state" hidden>
+          Für die aktuelle Filterauswahl sind keine Fristen vorhanden.
+        </p>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details">
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">Seite neu laden</button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">Schließen</button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="application/json" id="deadline-data">
+      [
+        {
+          "id": "DL-2025-001",
+          "title": "Einspruchsschrift an das Arbeitsgericht übermitteln",
+          "caseNumber": "A-2024-017",
+          "client": "Eva Schmidt",
+          "dueDate": "2025-11-06",
+          "status": "today",
+          "responsible": "RA Felix Bauer",
+          "type": "Gerichtliche Frist",
+          "notes": "Mandantin hat Änderungen am Morgen bestätigt.",
+          "tags": ["Arbeitsrecht", "Gericht"],
+          "location": "Arbeitsgericht München"
+        },
+        {
+          "id": "DL-2025-002",
+          "title": "Beschwerdebegründung vorbereiten",
+          "caseNumber": "V-2024-001",
+          "client": "Müller GmbH",
+          "dueDate": "2025-11-04",
+          "status": "overdue",
+          "responsible": "RAin Julia Wagner",
+          "type": "Fristverlängerung beantragt",
+          "notes": "Prüfung eingegangener Unterlagen, Rücksprache mit Mandant steht aus.",
+          "tags": ["Vertragsrecht"],
+          "location": "OLG Nürnberg"
+        },
+        {
+          "id": "DL-2025-003",
+          "title": "Versäumnisurteil prüfen und Wiedereinsetzung veranlassen",
+          "caseNumber": "S-2024-032",
+          "client": "Contoso AG",
+          "dueDate": "2025-11-01",
+          "status": "overdue",
+          "responsible": "RA Markus Lindner",
+          "type": "Gerichtliche Wiedereinsetzung",
+          "notes": "Entscheidung muss mit Compliance abgestimmt werden.",
+          "tags": ["Steuerrecht", "Fristsicherung"],
+          "location": "Finanzgericht Köln"
+        },
+        {
+          "id": "DL-2025-004",
+          "title": "Vergleichsentwurf finalisieren und versenden",
+          "caseNumber": "I-2024-004",
+          "client": "GreenTech Holding",
+          "dueDate": "2025-11-09",
+          "status": "soon",
+          "responsible": "RAin Selma Ortiz",
+          "type": "Vergleichsverhandlung",
+          "notes": "Finanzielle Anpassungen laut letzter Vorstandsrunde einarbeiten.",
+          "tags": ["Investitionsrecht"],
+          "location": "Videokonferenz"
+        },
+        {
+          "id": "DL-2025-005",
+          "title": "Sachverhaltsdarstellung für Mietprozess vervollständigen",
+          "caseNumber": "M-2023-089",
+          "client": "Jonas Weber",
+          "dueDate": "2025-11-11",
+          "status": "soon",
+          "responsible": "RAin Laura Peters",
+          "type": "Mandantenabstimmung",
+          "notes": "Nachreichung der Nebenkostenabrechnungen erforderlich.",
+          "tags": ["Mietrecht"],
+          "location": "Kanzlei"
+        },
+        {
+          "id": "DL-2025-006",
+          "title": "Compliance-Update im Mandantenportal veröffentlichen",
+          "caseNumber": "C-2024-054",
+          "client": "FutureLabs GmbH",
+          "dueDate": "2025-11-20",
+          "status": "upcoming",
+          "responsible": "RA Noah Klein",
+          "type": "Mandanteninformation",
+          "notes": "Freigabe durch Marketing abwarten.",
+          "tags": ["Datenschutz"],
+          "location": "Mandantenportal"
+        },
+        {
+          "id": "DL-2025-007",
+          "title": "Beweismittelübersicht für Kartellverfahren aufbereiten",
+          "caseNumber": "K-2024-055",
+          "client": "Nordwind AG",
+          "dueDate": "2025-11-27",
+          "status": "upcoming",
+          "responsible": "RAin Miriam Holz",
+          "type": "Behördenabgabe",
+          "notes": "Zusätzliche Dokumente vom Mandanten angefordert.",
+          "tags": ["Kartellrecht"],
+          "location": "Bundeskartellamt"
+        },
+        {
+          "id": "DL-2025-008",
+          "title": "Fristverlängerung beantragt – Rückmeldung beobachten",
+          "caseNumber": "B-2024-072",
+          "client": "Skyline Projektentwicklung",
+          "dueDate": "2025-10-30",
+          "status": "completed",
+          "responsible": "RA Paul Steiner",
+          "type": "Fristverlängerung",
+          "completedDate": "2025-11-03",
+          "notes": "Verlängerung wurde bewilligt, neue Frist 20.11.2025.",
+          "tags": ["Baurecht"],
+          "location": "LG Frankfurt"
+        },
+        {
+          "id": "DL-2025-009",
+          "title": "Gutachtenentwurf an Mandantin senden",
+          "caseNumber": "F-2024-011",
+          "client": "Familie Krause",
+          "dueDate": "2025-11-06",
+          "status": "today",
+          "responsible": "RAin Nadine Vogt",
+          "type": "Familiengericht",
+          "notes": "Letzte redaktionelle Prüfung erforderlich.",
+          "tags": ["Familienrecht"],
+          "location": "Kanzlei"
+        }
+      ]
+    </script>
+
+    <script src="assets/js/app.js" type="module"></script>
+    <script src="assets/js/deadline-board.js" type="module"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
           <a class="btn btn-secondary" href="template-assistant.html">Vorlagen-Assistent</a>
           <a class="btn btn-secondary" href="time-tracking.html">Zeiterfassung</a>
           <a class="btn btn-secondary" href="performance-overview.html">Leistungsübersicht</a>
+          <a class="btn btn-secondary" href="deadline-board.html">Fristen-Board</a>
           <a class="btn btn-secondary" href="erv-package-builder.html">ERV-Paket-Builder</a>
           <a class="btn btn-secondary" href="invoice-wizard.html">Rechnungs-Wizard</a>
           <a class="btn btn-secondary" href="open-items.html">Offene Posten</a>


### PR DESCRIPTION
## Summary
- add a dedicated Fristen-Board page with summary widgets, filters, and sample data
- implement the deadline-board module to render color-coded columns, cards, and filter feedback
- extend shared styles, navigation, and ToDo list to surface the new page

## Testing
- no automated tests were run (HTML/JS only)


------
https://chatgpt.com/codex/tasks/task_e_690c9e336ecc8320b5bad6b9a5b48a7c