### PR TITLE
Add interactive appointment calendar module

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -64,8 +64,8 @@ Beim Umsetzen jeder Aufgabe beachtest du folgende Richtlinien:
 16. **Fristen-Board** – Baue ein farbcodiertes Board mit Fristen (z. B. grün = offen, rot = überfällig).
     Status: ✅ erledigt – 2025-11-06
 
-17. **Termin-Kalender** – Erstelle eine Kalenderansicht mit anstehenden Gerichtsterminen oder Besprechungen.  
-    Status: ⬜
+17. **Termin-Kalender** – Erstelle eine Kalenderansicht mit anstehenden Gerichtsterminen oder Besprechungen.
+    Status: ✅ erledigt – 2025-11-06
 
 18. **Rollen-basierte UI-Sichtbarkeit** – Passe bestehende Seiten/Module so an, dass sie je nach aktuell angemeldeter Rolle angezeigt oder verborgen werden. Für den Mock reicht eine Dropdown-Auswahl.  
     Status: ⬜

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -4391,3 +4391,478 @@ body {
     grid-template-columns: 1fr;
   }
 }
+
+.calendar-main {
+  width: 100%;
+  align-items: center;
+}
+
+.calendar-board {
+  width: min(1200px, 100%);
+  background: #fff;
+  border-radius: 20px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  box-shadow: 0 22px 50px rgba(31, 60, 136, 0.12);
+  border: 1px solid rgba(31, 60, 136, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.calendar-board__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(1rem, 3vw, 2rem);
+}
+
+.calendar-board__description {
+  margin: 0.35rem 0 0;
+  max-width: 60ch;
+  color: #4b5563;
+}
+
+.calendar-board__nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.calendar-board__nav-button {
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  font-size: 1.25rem;
+}
+
+.calendar-board__current-month {
+  font-weight: 600;
+  min-width: 10rem;
+  text-align: center;
+  text-transform: capitalize;
+}
+
+.calendar-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem clamp(1rem, 3vw, 1.5rem);
+  background: rgba(47, 116, 192, 0.06);
+  border-radius: 16px;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  border: 1px solid rgba(47, 116, 192, 0.12);
+}
+
+.calendar-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.calendar-filter__label {
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #1f3c88;
+  font-weight: 600;
+}
+
+.calendar-filter--checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.calendar-filter-summary {
+  margin: 0;
+  font-weight: 500;
+  color: #1f3c88;
+}
+
+.calendar-board__content {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.calendar-grid-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(31, 60, 136, 0.1);
+  background: linear-gradient(180deg, rgba(47, 116, 192, 0.08), rgba(255, 255, 255, 0.9));
+}
+
+.calendar-grid__weekday {
+  padding: 0.75rem;
+  text-align: center;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  color: #1f3c88;
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(4px);
+}
+
+.calendar-grid__cell {
+  min-height: 160px;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(31, 60, 136, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.calendar-grid__cell--outside {
+  background: rgba(241, 245, 249, 0.65);
+  color: #94a3b8;
+}
+
+.calendar-grid__cell--today {
+  border-color: rgba(47, 116, 192, 0.55);
+  box-shadow: inset 0 0 0 2px rgba(47, 116, 192, 0.3);
+}
+
+.calendar-grid__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.calendar-grid__day {
+  font-weight: 600;
+  font-size: 1.15rem;
+}
+
+.calendar-grid__badge {
+  background: rgba(47, 116, 192, 0.15);
+  color: #1f3c88;
+  border-radius: 999px;
+  padding: 0.2rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.calendar-grid__events {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.calendar-grid__empty {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.calendar-event {
+  width: 100%;
+  border: 1px solid rgba(47, 116, 192, 0.25);
+  border-radius: 12px;
+  background: rgba(47, 116, 192, 0.08);
+  padding: 0.55rem 0.75rem;
+  text-align: left;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #1f3c88;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.calendar-event:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 15px rgba(15, 23, 42, 0.15);
+}
+
+.calendar-event:focus-visible {
+  outline: 3px solid rgba(47, 116, 192, 0.5);
+  outline-offset: 2px;
+}
+
+.calendar-event--selected {
+  border-color: rgba(47, 116, 192, 0.6);
+  background: rgba(47, 116, 192, 0.18);
+  box-shadow: 0 10px 18px rgba(47, 116, 192, 0.25);
+}
+
+.calendar-event--hearing {
+  border-color: rgba(220, 38, 38, 0.45);
+  background: rgba(220, 38, 38, 0.08);
+  color: #991b1b;
+}
+
+.calendar-event--meeting {
+  border-color: rgba(16, 185, 129, 0.45);
+  background: rgba(16, 185, 129, 0.08);
+  color: #047857;
+}
+
+.calendar-event--deadline {
+  border-color: rgba(251, 191, 36, 0.55);
+  background: rgba(251, 191, 36, 0.12);
+  color: #b45309;
+}
+
+.calendar-event--workshop {
+  border-color: rgba(139, 92, 246, 0.5);
+  background: rgba(139, 92, 246, 0.12);
+  color: #5b21b6;
+}
+
+.calendar-event--critical {
+  box-shadow: inset 0 0 0 2px rgba(220, 38, 38, 0.4);
+}
+
+.calendar-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+.calendar-upcoming {
+  background: rgba(47, 116, 192, 0.06);
+  border-radius: 16px;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  border: 1px solid rgba(47, 116, 192, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.calendar-upcoming__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.calendar-upcoming__item {
+  margin: 0;
+}
+
+.calendar-upcoming__button {
+  width: 100%;
+  background: #fff;
+  border: 1px solid rgba(47, 116, 192, 0.2);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.calendar-upcoming__button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.12);
+}
+
+.calendar-upcoming__button--selected {
+  border-color: rgba(47, 116, 192, 0.6);
+  box-shadow: 0 12px 20px rgba(47, 116, 192, 0.25);
+}
+
+.calendar-upcoming__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: #1f3c88;
+}
+
+.calendar-upcoming__relative {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.calendar-upcoming__title {
+  font-weight: 600;
+  color: #1f2933;
+}
+
+.calendar-upcoming__case {
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.calendar-upcoming__badge {
+  align-self: flex-start;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(47, 116, 192, 0.15);
+  color: #1f3c88;
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+}
+
+.calendar-upcoming__empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.calendar-detail {
+  background: #fff;
+  border-radius: 16px;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  border: 1px solid rgba(31, 60, 136, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.calendar-detail__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.calendar-detail__datetime {
+  margin: 0;
+  color: #1f3c88;
+  font-weight: 600;
+}
+
+.calendar-detail__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.calendar-detail__badge {
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(47, 116, 192, 0.15);
+  color: #1f3c88;
+}
+
+.calendar-detail__badge--hearing {
+  background: rgba(220, 38, 38, 0.12);
+  color: #991b1b;
+}
+
+.calendar-detail__badge--meeting {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+.calendar-detail__badge--deadline {
+  background: rgba(251, 191, 36, 0.18);
+  color: #92400e;
+}
+
+.calendar-detail__badge--workshop {
+  background: rgba(139, 92, 246, 0.2);
+  color: #5b21b6;
+}
+
+.calendar-detail__badge--court {
+  background: rgba(220, 38, 38, 0.15);
+  color: #991b1b;
+}
+
+.calendar-detail__badge--office {
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+.calendar-detail__badge--remote {
+  background: rgba(20, 184, 166, 0.16);
+  color: #0f766e;
+}
+
+.calendar-detail__badge--critical {
+  background: rgba(220, 38, 38, 0.18);
+  color: #7f1d1d;
+}
+
+.calendar-detail__properties {
+  display: grid;
+  grid-template-columns: minmax(0, 140px) minmax(0, 1fr);
+  gap: 0.4rem 1rem;
+  margin: 0;
+}
+
+.calendar-detail__properties dt {
+  font-weight: 600;
+  color: #1f3c88;
+}
+
+.calendar-detail__properties dd {
+  margin: 0;
+  color: #1f2933;
+}
+
+.calendar-empty-state {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+@media (max-width: 1024px) {
+  .calendar-board__content {
+    grid-template-columns: 1fr;
+  }
+
+  .calendar-sidebar {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .calendar-upcoming,
+  .calendar-detail {
+    flex: 1 1 280px;
+  }
+}
+
+@media (max-width: 768px) {
+  .calendar-grid__cell {
+    min-height: 140px;
+  }
+
+  .calendar-sidebar {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 600px) {
+  .calendar-filters {
+    grid-template-columns: 1fr;
+  }
+
+  .calendar-filter--checkbox {
+    align-items: flex-start;
+  }
+
+  .calendar-board__nav {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .calendar-board__current-month {
+    min-width: auto;
+  }
+
+  .calendar-grid__weekday {
+    font-size: 0.7rem;
+  }
+}

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -1,0 +1,667 @@
+import { overlayInstance } from './app.js';
+
+const dataElement = document.getElementById('calendar-data');
+const calendarGrid = document.getElementById('calendar-grid');
+const currentMonthEl = document.getElementById('calendar-current-month');
+const summaryEl = document.getElementById('calendar-filter-summary');
+const emptyStateEl = document.getElementById('calendar-empty-state');
+const upcomingListEl = document.getElementById('calendar-upcoming-list');
+const upcomingEmptyEl = document.getElementById('calendar-upcoming-empty');
+const detailBodyEl = document.getElementById('calendar-detail-body');
+const prevButton = document.getElementById('calendar-prev');
+const nextButton = document.getElementById('calendar-next');
+const searchInput = document.getElementById('calendar-search');
+const typeSelect = document.getElementById('calendar-type-filter');
+const locationSelect = document.getElementById('calendar-location-filter');
+const focusCriticalCheckbox = document.getElementById('calendar-focus-critical');
+
+if (!dataElement || !calendarGrid || !currentMonthEl) {
+  console.warn('Kalender konnte nicht initialisiert werden.');
+}
+
+const weekdayFormatter = new Intl.DateTimeFormat('de-DE', {
+  weekday: 'long',
+});
+
+const monthFormatter = new Intl.DateTimeFormat('de-DE', {
+  month: 'long',
+  year: 'numeric',
+});
+
+const dayFormatter = new Intl.DateTimeFormat('de-DE', {
+  day: 'numeric',
+  month: 'numeric',
+});
+
+const fullDateTimeFormatter = new Intl.DateTimeFormat('de-DE', {
+  dateStyle: 'full',
+  timeStyle: 'short',
+});
+
+const timeFormatter = new Intl.DateTimeFormat('de-DE', {
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat('de', {
+  numeric: 'auto',
+});
+
+let events = [];
+let filteredEvents = [];
+let currentYear;
+let currentMonthIndex;
+let selectedEventId = null;
+
+function parseDate(value) {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed;
+  }
+
+  // Versuch mit explizitem lokalen Datum
+  const fallback = new Date(`${value}T00:00`);
+  if (!Number.isNaN(fallback.getTime())) {
+    return fallback;
+  }
+
+  return null;
+}
+
+function normalizeEvent(entry) {
+  const start = parseDate(entry.dateTime ?? entry.start ?? entry.date);
+  if (!start) {
+    return null;
+  }
+
+  const normalizedType = (entry.type ?? 'meeting').toString().trim().toLowerCase();
+  const locationType = (entry.locationType ?? '').toString().trim().toLowerCase();
+
+  return {
+    id: entry.id ?? crypto.randomUUID?.() ?? `event-${Math.random().toString(16).slice(2)}`,
+    title: (entry.title ?? 'Unbenannter Termin').toString().trim(),
+    type: normalizedType,
+    location: (entry.location ?? 'Ort unbekannt').toString().trim(),
+    locationType: locationType || inferLocationType(entry.location),
+    caseNumber: (entry.caseNumber ?? '').toString().trim(),
+    client: (entry.client ?? '').toString().trim(),
+    participants: Array.isArray(entry.participants)
+      ? entry.participants.map((item) => item.toString().trim()).filter(Boolean)
+      : [],
+    notes: (entry.notes ?? '').toString().trim(),
+    start,
+    dateKey: buildDateKey(start),
+  };
+}
+
+function inferLocationType(location) {
+  const value = (location ?? '').toString().toLowerCase();
+  if (!value) return '';
+  if (value.includes('videokonferenz') || value.includes('remote') || value.includes('teams') || value.includes('zoom')) {
+    return 'remote';
+  }
+  if (value.includes('gericht')) {
+    return 'court';
+  }
+  if (value.includes('kanzlei') || value.includes('büro') || value.includes('office')) {
+    return 'office';
+  }
+  return '';
+}
+
+function buildDateKey(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function differenceInDays(startDate, endDate) {
+  const start = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+  const end = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate());
+  const msPerDay = 24 * 60 * 60 * 1000;
+  return Math.round((end - start) / msPerDay);
+}
+
+function isCritical(event) {
+  const now = new Date();
+  const daysUntil = differenceInDays(now, event.start);
+  if (daysUntil <= 2 && daysUntil >= 0) {
+    return true;
+  }
+  return event.type === 'hearing' || event.type === 'deadline';
+}
+
+function parseEvents() {
+  if (!dataElement) {
+    events = [];
+    return;
+  }
+
+  try {
+    const raw = dataElement.textContent ?? '[]';
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      events = [];
+      return;
+    }
+
+    events = parsed
+      .map((entry) => {
+        try {
+          return normalizeEvent(entry);
+        } catch (error) {
+          console.error('Termin konnte nicht normalisiert werden.', error);
+          return null;
+        }
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.start - b.start);
+  } catch (error) {
+    console.error('Kalenderdaten konnten nicht geladen werden.', error);
+    overlayInstance?.show?.({
+      title: 'Kalender konnte nicht geladen werden',
+      message: 'Die Terminliste ließ sich nicht verarbeiten.',
+      details: error,
+    });
+    events = [];
+  }
+}
+
+function initialiseCurrentMonth() {
+  const today = new Date();
+  const firstUpcoming = events.find((event) => event.start >= today);
+  const reference = firstUpcoming ? firstUpcoming.start : today;
+  currentYear = reference.getFullYear();
+  currentMonthIndex = reference.getMonth();
+}
+
+function updateCurrentMonthLabel() {
+  const current = new Date(currentYear, currentMonthIndex, 1);
+  currentMonthEl.textContent = monthFormatter.format(current);
+}
+
+function getMonthMatrix(year, monthIndex) {
+  const firstDayOfMonth = new Date(year, monthIndex, 1);
+  const daysInMonth = new Date(year, monthIndex + 1, 0).getDate();
+  const offset = (firstDayOfMonth.getDay() + 6) % 7; // Montag = 0
+  const totalCells = Math.ceil((offset + daysInMonth) / 7) * 7;
+
+  const cells = [];
+  for (let index = 0; index < totalCells; index += 1) {
+    const dayOffset = index - offset + 1;
+    const cellDate = new Date(year, monthIndex, dayOffset);
+    cells.push(cellDate);
+  }
+  return cells;
+}
+
+function clearCalendarGrid() {
+  const cells = calendarGrid.querySelectorAll('.calendar-grid__cell');
+  cells.forEach((cell) => cell.remove());
+}
+
+function renderCalendar() {
+  if (!calendarGrid) {
+    return;
+  }
+
+  clearCalendarGrid();
+
+  const cells = getMonthMatrix(currentYear, currentMonthIndex);
+  const today = new Date();
+  const todayKey = buildDateKey(today);
+
+  const eventsByDate = new Map();
+  filteredEvents.forEach((event) => {
+    const list = eventsByDate.get(event.dateKey) ?? [];
+    list.push(event);
+    eventsByDate.set(event.dateKey, list);
+  });
+
+  cells.forEach((date) => {
+    const cell = document.createElement('div');
+    cell.className = 'calendar-grid__cell';
+    cell.setAttribute('role', 'gridcell');
+
+    const dateKey = buildDateKey(date);
+    const isOutsideMonth = date.getMonth() !== currentMonthIndex;
+    if (isOutsideMonth) {
+      cell.classList.add('calendar-grid__cell--outside');
+      cell.setAttribute('aria-disabled', 'true');
+    }
+
+    if (dateKey === todayKey) {
+      cell.classList.add('calendar-grid__cell--today');
+    }
+
+    const meta = document.createElement('div');
+    meta.className = 'calendar-grid__meta';
+    const dayNumber = document.createElement('span');
+    dayNumber.className = 'calendar-grid__day';
+    dayNumber.textContent = String(date.getDate());
+    meta.append(dayNumber);
+
+    const weekdayLabel = weekdayFormatter.format(date);
+    cell.setAttribute('aria-label', `${weekdayLabel}, ${dayFormatter.format(date)}.`);
+
+    if (dateKey === todayKey) {
+      const badge = document.createElement('span');
+      badge.className = 'calendar-grid__badge';
+      badge.textContent = 'Heute';
+      meta.append(badge);
+    }
+
+    cell.append(meta);
+
+    const eventsForDay = eventsByDate.get(dateKey) ?? [];
+    if (eventsForDay.length) {
+      const list = document.createElement('ul');
+      list.className = 'calendar-grid__events';
+
+      eventsForDay
+        .slice()
+        .sort((a, b) => a.start - b.start)
+        .forEach((event) => {
+          const item = document.createElement('li');
+          item.className = 'calendar-grid__event-item';
+
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'calendar-event';
+          button.dataset.eventId = event.id;
+          button.textContent = `${timeFormatter.format(event.start)} • ${event.title}`;
+          button.setAttribute('aria-label', `${event.title}, ${timeFormatter.format(event.start)} Uhr`);
+          button.addEventListener('click', () => selectEvent(event.id, { revealMonth: false }));
+
+          button.classList.add(`calendar-event--${event.type}`);
+          if (isCritical(event)) {
+            button.classList.add('calendar-event--critical');
+          }
+          if (event.id === selectedEventId) {
+            button.classList.add('calendar-event--selected');
+          }
+
+          item.append(button);
+          list.append(item);
+        });
+
+      cell.append(list);
+    } else if (!isOutsideMonth) {
+      const placeholder = document.createElement('p');
+      placeholder.className = 'calendar-grid__empty';
+      placeholder.textContent = 'Keine Termine';
+      cell.append(placeholder);
+    }
+
+    calendarGrid.append(cell);
+  });
+
+  const hasEventsInMonth = cells.some((date) => {
+    if (date.getMonth() !== currentMonthIndex) {
+      return false;
+    }
+    const key = buildDateKey(date);
+    return (eventsByDate.get(key)?.length ?? 0) > 0;
+  });
+
+  if (emptyStateEl) {
+    if (!hasEventsInMonth) {
+      emptyStateEl.removeAttribute('hidden');
+    } else {
+      emptyStateEl.setAttribute('hidden', '');
+    }
+  }
+}
+
+function getUpcomingEvents(daysRange = 30) {
+  const now = new Date();
+  const limit = new Date(now.getFullYear(), now.getMonth(), now.getDate() + daysRange + 1);
+  return filteredEvents
+    .filter((event) => event.start >= now && event.start < limit)
+    .sort((a, b) => a.start - b.start)
+    .slice(0, 8);
+}
+
+function renderUpcomingList() {
+  if (!upcomingListEl) {
+    return;
+  }
+
+  upcomingListEl.innerHTML = '';
+  const upcoming = getUpcomingEvents();
+
+  if (!upcoming.length) {
+    if (upcomingEmptyEl) {
+      upcomingEmptyEl.removeAttribute('hidden');
+    }
+    return;
+  }
+
+  if (upcomingEmptyEl) {
+    upcomingEmptyEl.setAttribute('hidden', '');
+  }
+
+  upcoming.forEach((event) => {
+    const item = document.createElement('li');
+    item.className = 'calendar-upcoming__item';
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'calendar-upcoming__button';
+    button.dataset.eventId = event.id;
+    button.addEventListener('click', () => selectEvent(event.id, { revealMonth: true }));
+
+    const header = document.createElement('div');
+    header.className = 'calendar-upcoming__meta';
+    const dateLabel = document.createElement('span');
+    dateLabel.className = 'calendar-upcoming__date';
+    dateLabel.textContent = `${weekdayFormatter.format(event.start).slice(0, 2)} · ${dayFormatter.format(event.start)} · ${timeFormatter.format(event.start)} Uhr`;
+    header.append(dateLabel);
+
+    const relative = new Date();
+    const diffDays = differenceInDays(relative, event.start);
+    const relativeLabel = document.createElement('span');
+    relativeLabel.className = 'calendar-upcoming__relative';
+    relativeLabel.textContent = relativeTimeFormatter.format(diffDays, 'day');
+    header.append(relativeLabel);
+
+    button.append(header);
+
+    const title = document.createElement('span');
+    title.className = 'calendar-upcoming__title';
+    title.textContent = event.title;
+    button.append(title);
+
+    if (event.caseNumber) {
+      const caseInfo = document.createElement('span');
+      caseInfo.className = 'calendar-upcoming__case';
+      caseInfo.textContent = `${event.caseNumber}${event.client ? ` – ${event.client}` : ''}`;
+      button.append(caseInfo);
+    } else if (event.client) {
+      const clientInfo = document.createElement('span');
+      clientInfo.className = 'calendar-upcoming__case';
+      clientInfo.textContent = event.client;
+      button.append(clientInfo);
+    }
+
+    const badge = document.createElement('span');
+    badge.className = 'calendar-upcoming__badge';
+    badge.textContent = mapTypeToLabel(event.type);
+    button.append(badge);
+
+    if (event.id === selectedEventId) {
+      button.classList.add('calendar-upcoming__button--selected');
+    }
+
+    item.append(button);
+    upcomingListEl.append(item);
+  });
+}
+
+function mapTypeToLabel(type) {
+  switch (type) {
+    case 'hearing':
+      return 'Gerichtstermin';
+    case 'meeting':
+      return 'Meeting';
+    case 'deadline':
+      return 'Frist';
+    case 'workshop':
+      return 'Workshop';
+    default:
+      return 'Termin';
+  }
+}
+
+function renderDetail(event) {
+  if (!detailBodyEl) {
+    return;
+  }
+
+  detailBodyEl.innerHTML = '';
+
+  const title = document.createElement('h4');
+  title.className = 'calendar-detail__title';
+  title.textContent = event.title;
+  detailBodyEl.append(title);
+
+  const when = document.createElement('p');
+  when.className = 'calendar-detail__datetime';
+  when.textContent = fullDateTimeFormatter.format(event.start);
+  detailBodyEl.append(when);
+
+  const badgeList = document.createElement('div');
+  badgeList.className = 'calendar-detail__badges';
+
+  const typeBadge = document.createElement('span');
+  typeBadge.className = `calendar-detail__badge calendar-detail__badge--${event.type}`;
+  typeBadge.textContent = mapTypeToLabel(event.type);
+  badgeList.append(typeBadge);
+
+  if (event.locationType) {
+    const locationBadge = document.createElement('span');
+    locationBadge.className = `calendar-detail__badge calendar-detail__badge--${event.locationType}`;
+    switch (event.locationType) {
+      case 'court':
+        locationBadge.textContent = 'Gericht';
+        break;
+      case 'office':
+        locationBadge.textContent = 'Kanzlei';
+        break;
+      case 'remote':
+        locationBadge.textContent = 'Remote';
+        break;
+      default:
+        locationBadge.textContent = 'Ort';
+    }
+    badgeList.append(locationBadge);
+  }
+
+  if (isCritical(event)) {
+    const criticalBadge = document.createElement('span');
+    criticalBadge.className = 'calendar-detail__badge calendar-detail__badge--critical';
+    criticalBadge.textContent = 'Kritisch';
+    badgeList.append(criticalBadge);
+  }
+
+  detailBodyEl.append(badgeList);
+
+  const descriptionList = document.createElement('dl');
+  descriptionList.className = 'calendar-detail__properties';
+
+  const addProperty = (label, value) => {
+    if (!value) return;
+    const term = document.createElement('dt');
+    term.textContent = label;
+    const dd = document.createElement('dd');
+    dd.textContent = value;
+    descriptionList.append(term, dd);
+  };
+
+  addProperty('Ort', event.location);
+  addProperty('Aktenzeichen', event.caseNumber || undefined);
+  addProperty('Mandant:in', event.client || undefined);
+
+  if (event.participants.length) {
+    addProperty('Teilnehmende', event.participants.join(', '));
+  }
+
+  if (event.notes) {
+    addProperty('Hinweise', event.notes);
+  }
+
+  detailBodyEl.append(descriptionList);
+}
+
+function resetDetailView() {
+  if (!detailBodyEl) {
+    return;
+  }
+  detailBodyEl.innerHTML = '';
+  const message = document.createElement('p');
+  message.textContent = 'Wählen Sie einen Termin aus der Kalenderansicht oder der Liste, um Details zu sehen.';
+  detailBodyEl.append(message);
+}
+
+function selectEvent(eventId, { revealMonth }) {
+  const event = filteredEvents.find((item) => item.id === eventId);
+  if (!event) {
+    return;
+  }
+
+  selectedEventId = eventId;
+
+  if (revealMonth) {
+    currentYear = event.start.getFullYear();
+    currentMonthIndex = event.start.getMonth();
+    updateCurrentMonthLabel();
+    renderCalendar();
+  } else {
+    updateSelectedEventStyling();
+  }
+
+  renderDetail(event);
+  renderUpcomingList();
+}
+
+function updateSelectedEventStyling() {
+  const buttons = calendarGrid.querySelectorAll('.calendar-event');
+  buttons.forEach((button) => {
+    if (button.dataset.eventId === selectedEventId) {
+      button.classList.add('calendar-event--selected');
+    } else {
+      button.classList.remove('calendar-event--selected');
+    }
+  });
+
+  const upcomingButtons = upcomingListEl?.querySelectorAll('.calendar-upcoming__button') ?? [];
+  upcomingButtons.forEach((button) => {
+    if (button.dataset.eventId === selectedEventId) {
+      button.classList.add('calendar-upcoming__button--selected');
+    } else {
+      button.classList.remove('calendar-upcoming__button--selected');
+    }
+  });
+}
+
+function applyFilters() {
+  const query = (searchInput?.value ?? '').trim().toLowerCase();
+  const type = typeSelect?.value ?? 'all';
+  const location = locationSelect?.value ?? 'all';
+  const focusCritical = !!focusCriticalCheckbox?.checked;
+
+  filteredEvents = events.filter((event) => {
+    if (type !== 'all' && event.type !== type) {
+      return false;
+    }
+    if (location !== 'all') {
+      if (location === 'remote' && event.locationType !== 'remote') {
+        return false;
+      }
+      if (location === 'court' && event.locationType !== 'court') {
+        return false;
+      }
+      if (location === 'office' && event.locationType !== 'office') {
+        return false;
+      }
+    }
+    if (focusCritical && !isCritical(event)) {
+      return false;
+    }
+    if (query) {
+      const haystack = [
+        event.title,
+        event.caseNumber,
+        event.client,
+        event.location,
+        event.participants.join(' '),
+        mapTypeToLabel(event.type),
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      if (!haystack.includes(query)) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  updateSummary({ query, type, location, focusCritical });
+  renderCalendar();
+  renderUpcomingList();
+
+  if (!filteredEvents.some((event) => event.id === selectedEventId)) {
+    selectedEventId = null;
+    resetDetailView();
+  }
+}
+
+function updateSummary({ query, type, location, focusCritical }) {
+  if (!summaryEl) {
+    return;
+  }
+
+  const activeFilters = [];
+  if (query) {
+    activeFilters.push(`Suche nach "${query}"`);
+  }
+  if (type !== 'all') {
+    activeFilters.push(mapTypeToLabel(type));
+  }
+  if (location !== 'all') {
+    const label =
+      location === 'court' ? 'Gericht' : location === 'office' ? 'Kanzlei' : 'Remote';
+    activeFilters.push(label);
+  }
+  if (focusCritical) {
+    activeFilters.push('kritische Termine');
+  }
+
+  const count = filteredEvents.length;
+  const countLabel = count === 1 ? '1 Termin gefunden.' : `${count} Termine gefunden.`;
+  const filterLabel = activeFilters.length ? `Aktive Filter: ${activeFilters.join(', ')}.` : 'Keine Filter aktiv.';
+
+  summaryEl.textContent = `${countLabel} ${filterLabel}`;
+}
+
+function changeMonth(step) {
+  currentMonthIndex += step;
+  if (currentMonthIndex < 0) {
+    currentMonthIndex = 11;
+    currentYear -= 1;
+  } else if (currentMonthIndex > 11) {
+    currentMonthIndex = 0;
+    currentYear += 1;
+  }
+  updateCurrentMonthLabel();
+  renderCalendar();
+}
+
+function registerEvents() {
+  prevButton?.addEventListener('click', () => changeMonth(-1));
+  nextButton?.addEventListener('click', () => changeMonth(1));
+  searchInput?.addEventListener('input', () => applyFilters());
+  typeSelect?.addEventListener('change', () => applyFilters());
+  locationSelect?.addEventListener('change', () => applyFilters());
+  focusCriticalCheckbox?.addEventListener('change', () => applyFilters());
+}
+
+function initCalendar() {
+  if (!dataElement || !calendarGrid || !currentMonthEl) {
+    return;
+  }
+
+  parseEvents();
+  initialiseCurrentMonth();
+  updateCurrentMonthLabel();
+  registerEvents();
+  applyFilters();
+}
+
+initCalendar();

--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VeriLex – Termin-Kalender</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Termin-Kalender</h1>
+      <p class="app-subtitle">
+        Koordinieren Sie Gerichtstermine und Besprechungen, behalten Sie Konflikte im Blick und navigieren Sie schnell zu relevanten Akten.
+      </p>
+      <div class="welcome-actions">
+        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
+        <a class="btn btn-secondary" href="deadline-board.html">Fristen-Board</a>
+        <a class="btn btn-secondary" href="time-tracking.html">Zeiterfassung</a>
+      </div>
+    </header>
+
+    <main class="app-main calendar-main" aria-live="polite">
+      <section class="calendar-board" aria-labelledby="calendar-board-title">
+        <header class="calendar-board__header">
+          <div>
+            <h2 id="calendar-board-title">Termine des Monats</h2>
+            <p class="calendar-board__description">
+              Wechseln Sie zwischen Monaten, filtern Sie nach Terminart und durchsuchen Sie alle geplanten Ereignisse nach Aktenzeichen, Mandanten oder Stichworten.
+            </p>
+          </div>
+          <div class="calendar-board__nav" role="group" aria-label="Kalendermonate wechseln">
+            <button type="button" class="btn btn-secondary calendar-board__nav-button" id="calendar-prev" aria-label="Vorherigen Monat anzeigen">
+              ◀
+            </button>
+            <div class="calendar-board__current-month" id="calendar-current-month" role="status" aria-live="polite"></div>
+            <button type="button" class="btn btn-secondary calendar-board__nav-button" id="calendar-next" aria-label="Nächsten Monat anzeigen">
+              ▶
+            </button>
+          </div>
+        </header>
+
+        <form class="calendar-filters" aria-label="Termine filtern" novalidate>
+          <div class="calendar-filter">
+            <label class="calendar-filter__label" for="calendar-search">Schnellsuche</label>
+            <input
+              type="search"
+              id="calendar-search"
+              name="search"
+              placeholder="Nach Titel, Aktenzeichen, Mandant oder Ort suchen"
+              autocomplete="off"
+              spellcheck="false"
+              aria-describedby="calendar-filter-summary"
+            />
+          </div>
+          <div class="calendar-filter">
+            <label class="calendar-filter__label" for="calendar-type-filter">Terminart</label>
+            <select id="calendar-type-filter" name="type">
+              <option value="all">Alle Termine</option>
+              <option value="hearing">Gerichtstermine</option>
+              <option value="meeting">Mandanten- &amp; Team-Meetings</option>
+              <option value="deadline">Fristbezogene Termine</option>
+              <option value="workshop">Workshops &amp; Schulungen</option>
+            </select>
+          </div>
+          <div class="calendar-filter">
+            <label class="calendar-filter__label" for="calendar-location-filter">Standort</label>
+            <select id="calendar-location-filter" name="location">
+              <option value="all">Alle Standorte</option>
+              <option value="remote">Remote / Videokonferenz</option>
+              <option value="court">Gericht</option>
+              <option value="office">Kanzlei</option>
+            </select>
+          </div>
+          <div class="calendar-filter calendar-filter--checkbox">
+            <input type="checkbox" id="calendar-focus-critical" name="focusCritical" />
+            <label for="calendar-focus-critical">Nur kritische Termine hervorheben</label>
+          </div>
+        </form>
+
+        <p id="calendar-filter-summary" class="calendar-filter-summary" role="status"></p>
+
+        <div class="calendar-board__content">
+          <section class="calendar-grid-wrapper" aria-labelledby="calendar-grid-title">
+            <h3 id="calendar-grid-title" class="visually-hidden">Kalenderansicht</h3>
+            <div class="calendar-grid" role="grid" aria-readonly="true" id="calendar-grid">
+              <div class="calendar-grid__weekday" role="columnheader">Mo</div>
+              <div class="calendar-grid__weekday" role="columnheader">Di</div>
+              <div class="calendar-grid__weekday" role="columnheader">Mi</div>
+              <div class="calendar-grid__weekday" role="columnheader">Do</div>
+              <div class="calendar-grid__weekday" role="columnheader">Fr</div>
+              <div class="calendar-grid__weekday" role="columnheader">Sa</div>
+              <div class="calendar-grid__weekday" role="columnheader">So</div>
+            </div>
+            <p id="calendar-empty-state" class="calendar-empty-state" hidden>
+              Für diesen Monat liegen keine Termine vor, die den aktuellen Filtern entsprechen.
+            </p>
+          </section>
+
+          <aside class="calendar-sidebar">
+            <section class="calendar-upcoming" aria-labelledby="calendar-upcoming-title">
+              <h3 id="calendar-upcoming-title">Nächste Termine</h3>
+              <ol class="calendar-upcoming__list" id="calendar-upcoming-list"></ol>
+              <p id="calendar-upcoming-empty" class="calendar-upcoming__empty" hidden>
+                Keine passenden Termine in den nächsten 30 Tagen.
+              </p>
+            </section>
+
+            <section class="calendar-detail" aria-labelledby="calendar-detail-title">
+              <h3 id="calendar-detail-title">Termindetails</h3>
+              <div id="calendar-detail-body" class="calendar-detail__body">
+                <p>Wählen Sie einen Termin aus der Kalenderansicht oder der Liste, um Details zu sehen.</p>
+              </div>
+            </section>
+          </aside>
+        </div>
+      </section>
+    </main>
+
+    <div
+      id="global-error-overlay"
+      class="error-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-overlay-title"
+      aria-describedby="error-overlay-message"
+      hidden
+    >
+      <div class="error-overlay__content" role="document">
+        <header class="error-overlay__header">
+          <h2 id="error-overlay-title">Ein unerwarteter Fehler ist aufgetreten</h2>
+          <button
+            type="button"
+            class="error-overlay__close"
+            aria-label="Fehlermeldung schließen"
+            data-error-action="dismiss"
+          >
+            ×
+          </button>
+        </header>
+        <div id="error-overlay-message" class="error-overlay__message"></div>
+        <details class="error-overlay__details" hidden>
+          <summary>Technische Details einblenden</summary>
+          <pre id="error-overlay-details"></pre>
+        </details>
+        <footer class="error-overlay__footer">
+          <button type="button" class="btn" data-error-action="reload">Seite neu laden</button>
+          <button type="button" class="btn btn-secondary" data-error-action="dismiss">Schließen</button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="application/json" id="calendar-data">
+      [
+        {
+          "id": "event-001",
+          "title": "Gütetermin Arbeitsgericht Berlin",
+          "type": "hearing",
+          "dateTime": "2025-11-07T09:30",
+          "location": "Arbeitsgericht Berlin, Saal 3",
+          "locationType": "court",
+          "caseNumber": "A-2024-017",
+          "client": "Eva Schmidt",
+          "participants": ["RAin Julia König", "Mandantin Eva Schmidt"],
+          "notes": "Vergleichsvorschlag der Gegenseite prüfen"
+        },
+        {
+          "id": "event-002",
+          "title": "Strategiemeeting GreenTech",
+          "type": "meeting",
+          "dateTime": "2025-11-11T14:00",
+          "location": "VeriLex Kanzlei – Raum Konferenz 2",
+          "locationType": "office",
+          "caseNumber": "I-2024-004",
+          "client": "GreenTech Holding",
+          "participants": ["RA Dr. Lukas Stein", "Team M&amp;A"],
+          "notes": "Due-Diligence-Zwischenstand abstimmen"
+        },
+        {
+          "id": "event-003",
+          "title": "Hauptverhandlung Landgericht München",
+          "type": "hearing",
+          "dateTime": "2025-11-18T10:15",
+          "location": "LG München I, Sitzungssaal A 205",
+          "locationType": "court",
+          "caseNumber": "V-2024-001",
+          "client": "Müller GmbH",
+          "participants": ["RA Martin Berger", "Sachverständiger H. Reuter"],
+          "notes": "Zeugenreihenfolge final bestätigen"
+        },
+        {
+          "id": "event-004",
+          "title": "Mandanten-Update Contoso",
+          "type": "meeting",
+          "dateTime": "2025-11-21T09:00",
+          "location": "Videokonferenz (Teams)",
+          "locationType": "remote",
+          "caseNumber": "S-2024-032",
+          "client": "Contoso AG",
+          "participants": ["RAin Laura Seidel", "Steuerteam Contoso"],
+          "notes": "Überprüfung der offenen Behördenrückmeldungen"
+        },
+        {
+          "id": "event-005",
+          "title": "Interne Schulung: Neues Fristen-Tool",
+          "type": "workshop",
+          "dateTime": "2025-11-26T16:00",
+          "location": "VeriLex Kanzlei – Workshopraum",
+          "locationType": "office",
+          "caseNumber": "",
+          "client": "",
+          "participants": ["Alle Teamleitungen"],
+          "notes": "Rollout-Prozess abstimmen"
+        },
+        {
+          "id": "event-006",
+          "title": "Abgabefrist Schriftsatz Weber",
+          "type": "deadline",
+          "dateTime": "2025-11-28T12:00",
+          "location": "VeriLex Kanzlei",
+          "locationType": "office",
+          "caseNumber": "M-2023-089",
+          "client": "Familie Krause",
+          "participants": ["RAin Sophia Brandt"],
+          "notes": "Letzte Abstimmung mit Mandanten am Vortag"
+        },
+        {
+          "id": "event-007",
+          "title": "Erörterungstermin Amtsgericht Hamburg",
+          "type": "hearing",
+          "dateTime": "2025-12-03T11:30",
+          "location": "AG Hamburg, Saal 12",
+          "locationType": "court",
+          "caseNumber": "F-2024-011",
+          "client": "Familie Krause",
+          "participants": ["RAin Sophia Brandt"],
+          "notes": "Reiseplanung &amp; Unterlagencheck bis 01.12."
+        }
+      ]
+    </script>
+
+    <script src="assets/js/app.js" type="module"></script>
+    <script src="assets/js/calendar.js" type="module"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
           <a class="btn btn-secondary" href="document-management.html">Dokumentenverwaltung</a>
           <a class="btn btn-secondary" href="template-assistant.html">Vorlagen-Assistent</a>
           <a class="btn btn-secondary" href="time-tracking.html">Zeiterfassung</a>
+          <a class="btn btn-secondary" href="calendar.html">Termin-Kalender</a>
           <a class="btn btn-secondary" href="performance-overview.html">Leistungsübersicht</a>
           <a class="btn btn-secondary" href="deadline-board.html">Fristen-Board</a>
           <a class="btn btn-secondary" href="erv-package-builder.html">ERV-Paket-Builder</a>


### PR DESCRIPTION
## Summary
- add a dedicated Termin-Kalender page with month navigation, filters, and upcoming overview
- implement calendar.js to render the interactive calendar grid, details panel, and critical-term highlighting
- extend shared styles, surface the calendar entry point on the dashboard, and mark the ToDo item as complete

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_690cdebfe5ec8320960adf13c8ecaa02