### PR TITLE
Standardize Zur Übersicht back buttons across features

### DIFF
--- a/ai-assistant.html
+++ b/ai-assistant.html
@@ -15,8 +15,8 @@
     </header>
 
     <main class="app-main ai-assistant-main" aria-live="polite">
-      <nav class="case-breadcrumb" aria-label="Brotkrumen">
-        <a class="case-breadcrumb__link" href="index.html">&larr; Zur Startseite</a>
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
       </nav>
 
       <section class="app-card ai-assistant" aria-labelledby="ai-assistant-title" data-visible-for="all">

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2381,13 +2381,16 @@ body {
   align-items: stretch;
 }
 
+.back-navigation,
 .case-breadcrumb {
   width: min(1100px, 100%);
   margin: 0 auto clamp(0.5rem, 2vw, 1rem);
+  display: flex;
+  justify-content: flex-start;
 }
 
+.back-navigation__link,
 .case-breadcrumb__link {
-  color: var(--color-accent-strong);
   font-weight: 600;
   text-decoration: none;
   display: inline-flex;
@@ -2395,6 +2398,16 @@ body {
   gap: 0.35rem;
 }
 
+.back-navigation__link {
+  color: inherit;
+}
+
+.case-breadcrumb__link {
+  color: var(--color-accent-strong);
+}
+
+.back-navigation__link:hover,
+.back-navigation__link:focus,
 .case-breadcrumb__link:hover,
 .case-breadcrumb__link:focus {
   text-decoration: underline;

--- a/calendar.html
+++ b/calendar.html
@@ -15,13 +15,16 @@
         Koordinieren Sie Gerichtstermine und Besprechungen, behalten Sie Konflikte im Blick und navigieren Sie schnell zu relevanten Akten.
       </p>
       <div class="welcome-actions">
-        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
         <a class="btn btn-secondary" href="deadline-board.html">Fristen-Board</a>
         <a class="btn btn-secondary" href="time-tracking.html">Zeiterfassung</a>
       </div>
     </header>
 
     <main class="app-main calendar-main" aria-live="polite">
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
+      </nav>
+
       <section
         class="calendar-board"
         aria-labelledby="calendar-board-title"

--- a/compliance-checklist.html
+++ b/compliance-checklist.html
@@ -21,6 +21,10 @@
     </header>
 
     <main class="app-main compliance-main" aria-live="polite">
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
+      </nav>
+
       <section class="compliance-module" aria-labelledby="compliance-module-title" data-visible-for="partner,associate,assistant">
         <header class="compliance-module__header">
           <div>

--- a/deadline-board.html
+++ b/deadline-board.html
@@ -15,13 +15,16 @@
         Priorisieren Sie juristische Fristen, erkennen Sie Engpässe frühzeitig und koordinieren Sie Zuständigkeiten.
       </p>
       <div class="welcome-actions">
-        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
         <a class="btn btn-secondary" href="case-detail.html">Zu einer Akte</a>
         <a class="btn btn-secondary" href="open-items.html">Offene Posten</a>
       </div>
     </header>
 
     <main class="app-main deadline-main" aria-live="polite">
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
+      </nav>
+
       <section
         class="deadline-board"
         aria-labelledby="deadline-board-title"

--- a/document-management.html
+++ b/document-management.html
@@ -15,8 +15,8 @@
     </header>
 
     <main class="app-main document-manager-main" aria-live="polite">
-      <nav class="case-breadcrumb" aria-label="Brotkrumen">
-        <a class="case-breadcrumb__link" href="index.html">&larr; Zur Startseite</a>
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
       </nav>
 
       <section

--- a/email-integration.html
+++ b/email-integration.html
@@ -15,13 +15,16 @@
         Demo einer kanzleitypischen E-Mail-Ansicht mit Nachrichtenliste, Detailbereich und Schnellaktionen.
       </p>
       <div class="welcome-actions">
-        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
         <a class="btn btn-secondary" href="case-detail.html">Akten-Timeline</a>
         <a class="btn btn-secondary" href="document-management.html">Dokumentenverwaltung</a>
       </div>
     </header>
 
     <main class="app-main mail-main" aria-live="polite">
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
+      </nav>
+
       <section
         class="mail-layout"
         aria-labelledby="mail-title"

--- a/erv-package-builder.html
+++ b/erv-package-builder.html
@@ -18,8 +18,8 @@
     </header>
 
     <main class="app-main erv-builder-main" aria-live="polite">
-      <nav class="case-breadcrumb" aria-label="Navigation">
-        <a class="case-breadcrumb__link" href="index.html">&larr; Zur Startseite</a>
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
       </nav>
 
       <section

--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -17,8 +17,8 @@
     </header>
 
     <main class="app-main" aria-live="polite">
-      <nav class="wizard-breadcrumb" aria-label="Navigation">
-        <a class="wizard-breadcrumb__link" href="index.html">&larr; Zur Übersicht</a>
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
       </nav>
 
       <section

--- a/mandantenportal.html
+++ b/mandantenportal.html
@@ -15,6 +15,10 @@
     </header>
 
     <main class="app-main client-portal-main" aria-live="polite">
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
+      </nav>
+
       <section class="app-card client-portal-hero" aria-labelledby="client-portal-heading">
         <div class="client-portal-hero__header">
           <h2 id="client-portal-heading">Mandantenportal</h2>

--- a/mandate-wizard.html
+++ b/mandate-wizard.html
@@ -15,8 +15,8 @@
     </header>
 
     <main class="app-main" aria-live="polite">
-      <nav class="wizard-breadcrumb" aria-label="Navigation">
-        <a class="wizard-breadcrumb__link" href="index.html">&larr; Zur Übersicht</a>
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
       </nav>
 
       <section

--- a/open-items.html
+++ b/open-items.html
@@ -15,13 +15,16 @@
         Behalten Sie unbezahlte Rechnungen, offene Beträge und bereits beglichene Vorgänge transparent im Blick.
       </p>
       <div class="welcome-actions">
-        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
         <a class="btn btn-secondary" href="performance-overview.html">Leistungsübersicht</a>
         <a class="btn btn-secondary" href="invoice-wizard.html">Rechnungs-Wizard</a>
       </div>
     </header>
 
     <main class="app-main receivables-main" aria-live="polite">
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
+      </nav>
+
       <section
         class="receivables-board"
         aria-labelledby="receivables-title"

--- a/performance-overview.html
+++ b/performance-overview.html
@@ -15,12 +15,15 @@
         Analysieren Sie erfasste Tätigkeiten, filtern Sie nach Mandanten und behalten Sie Summen im Blick.
       </p>
       <div class="welcome-actions">
-        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
         <a class="btn btn-secondary" href="time-tracking.html">Zur Zeiterfassung</a>
       </div>
     </header>
 
     <main class="app-main performance-overview-main" aria-live="polite">
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
+      </nav>
+
       <section
         class="performance-overview"
         aria-labelledby="performance-overview-title"

--- a/risk-monitor.html
+++ b/risk-monitor.html
@@ -15,12 +15,15 @@
         Behalten Sie kritische Verfahren im Blick, priorisieren Sie Gegenmaßnahmen und erkennen Sie Trends.
       </p>
       <div class="welcome-actions">
-        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
         <a class="btn btn-secondary" href="dashboard.html">Zum Dashboard</a>
       </div>
     </header>
 
     <main class="app-main risk-monitor-main" aria-live="polite">
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
+      </nav>
+
       <section class="risk-overview" aria-labelledby="risk-overview-title" data-visible-for="partner,associate">
         <header class="risk-overview__header">
           <div>

--- a/team-capacity.html
+++ b/team-capacity.html
@@ -15,12 +15,15 @@
         Überwachen Sie Kapazitäten, Auslastung und kritische Mandate des gesamten Teams für die aktuelle Planungswoche.
       </p>
       <div class="welcome-actions">
-        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
         <a class="btn btn-secondary" href="dashboard.html">Zum Dashboard</a>
       </div>
     </header>
 
     <main class="app-main team-capacity-main" aria-live="polite">
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
+      </nav>
+
       <section
         class="app-card capacity-overview"
         aria-labelledby="capacity-overview-title"

--- a/template-assistant.html
+++ b/template-assistant.html
@@ -15,8 +15,8 @@
     </header>
 
     <main class="app-main template-assistant-main" aria-live="polite">
-      <nav class="case-breadcrumb" aria-label="Brotkrumen">
-        <a class="case-breadcrumb__link" href="index.html">&larr; Zur Startseite</a>
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
       </nav>
 
       <section

--- a/time-tracking.html
+++ b/time-tracking.html
@@ -12,12 +12,13 @@
     <header class="app-header">
       <h1>Zeiterfassung</h1>
       <p class="app-subtitle">Erfassen Sie Arbeitszeiten und behalten Sie Leistungen im Blick.</p>
-      <div class="welcome-actions">
-        <a class="btn btn-secondary" href="index.html">Zur Übersicht</a>
-      </div>
     </header>
 
     <main class="app-main time-tracking-layout" aria-live="polite">
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
+      </nav>
+
       <section
         class="app-card time-tracking-card"
         aria-labelledby="time-tracking-title"

--- a/workflow-designer.html
+++ b/workflow-designer.html
@@ -15,8 +15,8 @@
     </header>
 
     <main class="app-main workflow-designer-main" aria-live="polite">
-      <nav class="case-breadcrumb" aria-label="Brotkrumen">
-        <a class="case-breadcrumb__link" href="index.html">&larr; Zur Startseite</a>
+      <nav class="back-navigation" aria-label="Navigation">
+        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
       </nav>
 
       <section


### PR DESCRIPTION
## Summary
- use a consistent "Zur Übersicht" secondary button for back navigation on all feature pages
- align the back-navigation placement to the top-left for uniform layout
- update styling so the back button uses shared button visuals while preserving breadcrumb appearance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69282d653e508320a383c96da07bbbe0)