### PR TITLE
Add header overview navigation across modules

### DIFF
--- a/ai-assistant.html
+++ b/ai-assistant.html
@@ -10,15 +10,14 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+      </div>
       <h1>VeriLex Demo</h1>
       <p class="app-subtitle">KI-gestützte Unterstützung für Kanzleiteams</p>
     </header>
 
     <main class="app-main ai-assistant-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section class="app-card ai-assistant" aria-labelledby="ai-assistant-title" data-visible-for="all">
         <header class="ai-assistant__header">
           <div>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -64,6 +64,27 @@ body {
   box-shadow: 0 2px 18px rgba(15, 23, 42, 0.35);
 }
 
+.app-header__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin: 0 auto 1.25rem;
+  width: min(1100px, 100%);
+}
+
+.app-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.app-header__back {
+  text-decoration: none;
+}
+
 .security-banner {
   width: 100%;
   box-sizing: border-box;

--- a/calendar.html
+++ b/calendar.html
@@ -10,21 +10,20 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+        <div class="app-header__actions">
+          <a class="btn btn-secondary" href="deadline-board.html">Fristen-Board</a>
+          <a class="btn btn-secondary" href="time-tracking.html">Zeiterfassung</a>
+        </div>
+      </div>
       <h1>Termin-Kalender</h1>
       <p class="app-subtitle">
         Koordinieren Sie Gerichtstermine und Besprechungen, behalten Sie Konflikte im Blick und navigieren Sie schnell zu relevanten Akten.
       </p>
-      <div class="welcome-actions">
-        <a class="btn btn-secondary" href="deadline-board.html">Fristen-Board</a>
-        <a class="btn btn-secondary" href="time-tracking.html">Zeiterfassung</a>
-      </div>
     </header>
 
     <main class="app-main calendar-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="calendar-board"
         aria-labelledby="calendar-board-title"

--- a/compliance-checklist.html
+++ b/compliance-checklist.html
@@ -10,21 +10,20 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+        <div class="app-header__actions">
+          <a class="btn btn-secondary" href="dashboard.html">Zum Dashboard</a>
+          <a class="btn btn-secondary" href="risk-monitor.html">Risikomonitor öffnen</a>
+        </div>
+      </div>
       <h1>Kanzlei-Compliance &amp; Qualitätscheck</h1>
       <p class="app-subtitle">
         Überwachen Sie Kanzleivorgaben, dokumentieren Sie Prüfungen und behalten Sie kritische Punkte im Blick.
       </p>
-      <div class="welcome-actions">
-        <a class="btn btn-secondary" href="dashboard.html">Zum Dashboard</a>
-        <a class="btn btn-secondary" href="risk-monitor.html">Risikomonitor öffnen</a>
-      </div>
     </header>
 
     <main class="app-main compliance-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section class="compliance-module" aria-labelledby="compliance-module-title" data-visible-for="partner,associate,assistant">
         <header class="compliance-module__header">
           <div>

--- a/deadline-board.html
+++ b/deadline-board.html
@@ -10,21 +10,20 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+        <div class="app-header__actions">
+          <a class="btn btn-secondary" href="case-detail.html">Zu einer Akte</a>
+          <a class="btn btn-secondary" href="open-items.html">Offene Posten</a>
+        </div>
+      </div>
       <h1>Fristen-Board</h1>
       <p class="app-subtitle">
         Priorisieren Sie juristische Fristen, erkennen Sie Engpässe frühzeitig und koordinieren Sie Zuständigkeiten.
       </p>
-      <div class="welcome-actions">
-        <a class="btn btn-secondary" href="case-detail.html">Zu einer Akte</a>
-        <a class="btn btn-secondary" href="open-items.html">Offene Posten</a>
-      </div>
     </header>
 
     <main class="app-main deadline-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="deadline-board"
         aria-labelledby="deadline-board-title"

--- a/document-management.html
+++ b/document-management.html
@@ -10,15 +10,14 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+      </div>
       <h1>VeriLex Demo</h1>
       <p class="app-subtitle">Dokumentenverwaltung (Mock)</p>
     </header>
 
     <main class="app-main document-manager-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="app-card"
         aria-labelledby="document-dropzone-title"

--- a/email-integration.html
+++ b/email-integration.html
@@ -10,21 +10,20 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+        <div class="app-header__actions">
+          <a class="btn btn-secondary" href="case-detail.html">Akten-Timeline</a>
+          <a class="btn btn-secondary" href="document-management.html">Dokumentenverwaltung</a>
+        </div>
+      </div>
       <h1>VeriLex Inbox</h1>
       <p class="app-subtitle">
         Demo einer kanzleitypischen E-Mail-Ansicht mit Nachrichtenliste, Detailbereich und Schnellaktionen.
       </p>
-      <div class="welcome-actions">
-        <a class="btn btn-secondary" href="case-detail.html">Akten-Timeline</a>
-        <a class="btn btn-secondary" href="document-management.html">Dokumentenverwaltung</a>
-      </div>
     </header>
 
     <main class="app-main mail-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="mail-layout"
         aria-labelledby="mail-title"

--- a/erv-package-builder.html
+++ b/erv-package-builder.html
@@ -10,6 +10,9 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+      </div>
       <h1>Elektronisches Rechtsverkehrspaket vorbereiten</h1>
       <p class="app-subtitle">
         Sammeln Sie Dokumente, prüfen Sie Pflichtangaben und simulieren Sie die Übergabe an das Gericht – vollständig im
@@ -18,10 +21,6 @@
     </header>
 
     <main class="app-main erv-builder-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="erv-board"
         aria-labelledby="erv-builder-title"

--- a/invoice-wizard.html
+++ b/invoice-wizard.html
@@ -10,6 +10,9 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+      </div>
       <h1>Rechnung erstellen</h1>
       <p class="app-subtitle">
         Führen Sie erfasste Leistungen zusammen, prüfen Sie die Angaben und exportieren Sie eine Vorschau als PDF-Mock.
@@ -17,10 +20,6 @@
     </header>
 
     <main class="app-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="app-card wizard-card"
         aria-labelledby="invoice-wizard-title"

--- a/mandantenportal.html
+++ b/mandantenportal.html
@@ -10,15 +10,14 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+      </div>
       <h1>VeriLex Demo</h1>
       <p class="app-subtitle">Mandantenportal</p>
     </header>
 
     <main class="app-main client-portal-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section class="app-card client-portal-hero" aria-labelledby="client-portal-heading">
         <div class="client-portal-hero__header">
           <h2 id="client-portal-heading">Mandantenportal</h2>

--- a/mandate-wizard.html
+++ b/mandate-wizard.html
@@ -10,15 +10,14 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+      </div>
       <h1>VeriLex Demo</h1>
       <p class="app-subtitle">Mandatsanlage in vier Schritten</p>
     </header>
 
     <main class="app-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="app-card wizard-card"
         aria-labelledby="wizard-title"

--- a/open-items.html
+++ b/open-items.html
@@ -10,21 +10,20 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+        <div class="app-header__actions">
+          <a class="btn btn-secondary" href="performance-overview.html">Leistungsübersicht</a>
+          <a class="btn btn-secondary" href="invoice-wizard.html">Rechnungs-Wizard</a>
+        </div>
+      </div>
       <h1>Offene-Posten-Übersicht</h1>
       <p class="app-subtitle">
         Behalten Sie unbezahlte Rechnungen, offene Beträge und bereits beglichene Vorgänge transparent im Blick.
       </p>
-      <div class="welcome-actions">
-        <a class="btn btn-secondary" href="performance-overview.html">Leistungsübersicht</a>
-        <a class="btn btn-secondary" href="invoice-wizard.html">Rechnungs-Wizard</a>
-      </div>
     </header>
 
     <main class="app-main receivables-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="receivables-board"
         aria-labelledby="receivables-title"

--- a/performance-overview.html
+++ b/performance-overview.html
@@ -10,20 +10,19 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+        <div class="app-header__actions">
+          <a class="btn btn-secondary" href="time-tracking.html">Zur Zeiterfassung</a>
+        </div>
+      </div>
       <h1>Leistungsübersicht</h1>
       <p class="app-subtitle">
         Analysieren Sie erfasste Tätigkeiten, filtern Sie nach Mandanten und behalten Sie Summen im Blick.
       </p>
-      <div class="welcome-actions">
-        <a class="btn btn-secondary" href="time-tracking.html">Zur Zeiterfassung</a>
-      </div>
     </header>
 
     <main class="app-main performance-overview-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="performance-overview"
         aria-labelledby="performance-overview-title"

--- a/risk-monitor.html
+++ b/risk-monitor.html
@@ -10,20 +10,19 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+        <div class="app-header__actions">
+          <a class="btn btn-secondary" href="dashboard.html">Zum Dashboard</a>
+        </div>
+      </div>
       <h1>Risikomonitor für Mandate</h1>
       <p class="app-subtitle">
         Behalten Sie kritische Verfahren im Blick, priorisieren Sie Gegenmaßnahmen und erkennen Sie Trends.
       </p>
-      <div class="welcome-actions">
-        <a class="btn btn-secondary" href="dashboard.html">Zum Dashboard</a>
-      </div>
     </header>
 
     <main class="app-main risk-monitor-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section class="risk-overview" aria-labelledby="risk-overview-title" data-visible-for="partner,associate">
         <header class="risk-overview__header">
           <div>

--- a/team-capacity.html
+++ b/team-capacity.html
@@ -10,20 +10,19 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+        <div class="app-header__actions">
+          <a class="btn btn-secondary" href="dashboard.html">Zum Dashboard</a>
+        </div>
+      </div>
       <h1>Team-Auslastung</h1>
       <p class="app-subtitle">
         Überwachen Sie Kapazitäten, Auslastung und kritische Mandate des gesamten Teams für die aktuelle Planungswoche.
       </p>
-      <div class="welcome-actions">
-        <a class="btn btn-secondary" href="dashboard.html">Zum Dashboard</a>
-      </div>
     </header>
 
     <main class="app-main team-capacity-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="app-card capacity-overview"
         aria-labelledby="capacity-overview-title"

--- a/template-assistant.html
+++ b/template-assistant.html
@@ -10,15 +10,14 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+      </div>
       <h1>VeriLex Demo</h1>
       <p class="app-subtitle">Vorlagen-Assistent für Textbausteine</p>
     </header>
 
     <main class="app-main template-assistant-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="app-card template-assistant"
         aria-labelledby="template-assistant-title"

--- a/time-tracking.html
+++ b/time-tracking.html
@@ -10,15 +10,14 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+      </div>
       <h1>Zeiterfassung</h1>
       <p class="app-subtitle">Erfassen Sie Arbeitszeiten und behalten Sie Leistungen im Blick.</p>
     </header>
 
     <main class="app-main time-tracking-layout" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="app-card time-tracking-card"
         aria-labelledby="time-tracking-title"

--- a/workflow-designer.html
+++ b/workflow-designer.html
@@ -10,15 +10,14 @@
   </head>
   <body>
     <header class="app-header">
+      <div class="app-header__toolbar">
+        <a class="btn btn-secondary app-header__back" href="index.html">Zur Übersicht</a>
+      </div>
       <h1>VeriLex Demo</h1>
       <p class="app-subtitle">Visueller Workflow-Designer (Mock)</p>
     </header>
 
     <main class="app-main workflow-designer-main" aria-live="polite">
-      <nav class="back-navigation" aria-label="Navigation">
-        <a class="btn btn-secondary back-navigation__link" href="index.html">Zur Übersicht</a>
-      </nav>
-
       <section
         class="workflow-designer"
         aria-labelledby="workflow-designer-title"


### PR DESCRIPTION
## Summary
- add a consistent header toolbar with a Zur Übersicht button across feature modules
- align existing header quick actions with the new toolbar layout in the blue header area
- tidy navigation by removing in-content back links now covered by the header control

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69284153fc908320909d7a49e1c2c2c0)